### PR TITLE
Removes the notification top bar

### DIFF
--- a/src/partials/layout.html
+++ b/src/partials/layout.html
@@ -42,17 +42,6 @@
     ></script>
   </head>
   <body data-page="{{ page }}">
-    <!-- Notification top bar -->
-    <div class="p-2 text-center text-xs text-gray-700 bg-blue-200">
-      &#127881; Automate and learn with Smart cells in Livebook v0.6.
-      <a
-        class="font-medium border-b border-gray-700"
-        href="https://news.livebook.dev/v0.6-automate-and-learn-with-smart-cells-mxJJe"
-        target="_blank"
-        rel="noopener"
-        >Read the announcement</a
-      >.
-    </div>
     <!-- Navbar desktop -->
     <header
       class="m-auto w-full max-w-7xl px-4 py-6 hidden lg:flex items-center"


### PR DESCRIPTION
AnnounceKit has a "announce bar" feature that I'd like to use for promoting new blog pots on http://livebook.dev website. But, there is a hardcoded "top bar" on the Livebook website thas was being used to promote the last blog post

This PR removes the harcoded top bar, so we can use AnnounceKit's dynamic "announce bar" feature for promoting new blog posts on http://livebook.dev website.

## Before this PR
![image](https://user-images.githubusercontent.com/2719/181599620-2994ea14-8a90-4008-9932-6ea05aaff133.png)

## After this PR
![image](https://user-images.githubusercontent.com/2719/181599740-e1c5c6f6-fb60-4d93-9b4a-4fd90c1ccc77.png)
