### PR TITLE
Fixes minor spelling error on homepage

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -297,7 +297,7 @@
         class="mt-3 max-w-md md:max-w-xl text-gray-300 font-medium text-center"
       >
         There’s much to do with Livebook and its awesome features. Here is a
-        sneak peak:
+        sneak peek:
       </span>
     </div>
     <!-- Data -->


### PR DESCRIPTION
- This edit fixes the minor homepage spelling error of `sneak peak`; edits to `sneak peek`