### PR TITLE
Adds a few plausible custom events

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -23,8 +23,8 @@
   status = 302
 
 [[redirects]]
-  from = "/pa/js/script.js"
-  to = "https://plausible.io/js/script.js"
+  from = "/pa/js/script.tagged-events.js"
+  to = "https://plausible.io/js/script.tagged-events.js"
   status = 200
 
 [[redirects]]

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -66,7 +66,7 @@ function isPathActive(path) {
       defer
       data-domain="livebook.dev"
       data-api="/pa/api/event"
-      src="/pa/js/script.js"
+      src="/pa/js/script.tagged-events.js"
     ></script>
   </head>
   <body>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -114,7 +114,7 @@ const selectedIntegrations = integrations.filter((integration) =>
               designed for teams and businesses.</span
             >
             <a
-              class="px-5 py-3 lg:px-6 lg:py-3 bg-white rounded-lg border border-gray-300 mt-8"
+              class="px-5 py-3 lg:px-6 lg:py-3 bg-white rounded-lg border border-gray-300 mt-8 plausible-event-name=home+teams+cta+click"
               href="/teams"
             >
               <div

--- a/src/pages/teams.astro
+++ b/src/pages/teams.astro
@@ -64,7 +64,7 @@ const future = false;
           Teams and contribute to the development of the roadmap.
         </span>
         <a
-          class="px-6 py-4 flex items-center justify-center rounded-xl bg-gray-50 hover:bg-brand-pink text-gray-700 hover:text-gray-100 hover: border hover:border-gray-100 transition duration-150 ease-in-out"
+          class="px-6 py-4 flex items-center justify-center rounded-xl bg-gray-50 hover:bg-brand-pink text-gray-700 hover:text-gray-100 hover: border hover:border-gray-100 transition duration-150 ease-in-out plausible-event-name=teams+early+access+main+cta+click"
           href="https://docs.google.com/forms/d/e/1FAIpQLScDfvUqT4f_s95dqNGyoXwVMD_Vl059jT6r5MPgXB99XVMCuw/viewform"
         >
           <Icon icon="arrow-right-line" class="text-xl" />
@@ -151,7 +151,7 @@ const future = false;
                 >Livebook Teams is still in development. We want to get feedback
                 from beta users and understand their use cases to expand and improve the product.
               </span>
-              <a class="button button-blue mt-6" href="https://docs.google.com/forms/d/e/1FAIpQLScDfvUqT4f_s95dqNGyoXwVMD_Vl059jT6r5MPgXB99XVMCuw/viewform">
+              <a class="button button-blue mt-6 plausible-event-name=teams+join+beta+cta+click" href="https://docs.google.com/forms/d/e/1FAIpQLScDfvUqT4f_s95dqNGyoXwVMD_Vl059jT6r5MPgXB99XVMCuw/viewform">
                 <span>Join the beta program</span>
               </a>
             </div>


### PR DESCRIPTION
Now that we have a published Teams landing page, I'd like to track some custom events, like nº of clicks the "join beta" CTA gets.

This PR changes the integration with Plausible to use their JS lib that provides [custom event goals](https://plausible.io/docs/custom-event-goals), as well as adds some custom events.