### PR TITLE
Fixes links to integrations

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -333,7 +333,7 @@ const selectedIntegrations = integrations.filter((integration) =>
                 style={{ order: idx + 1 }}
               >
                 <a
-                  href="/integrations/elixir"
+                  href={`/integrations/${integration.id}`}
                   class="flex flex-col items-center"
                 >
                   <img


### PR DESCRIPTION
In the integration sections of the homepage:

![CleanShot 2023-07-20 at 11 34 59](https://github.com/livebook-dev/livebook.dev/assets/2719/687188fc-2a3f-4810-87b7-9a091a6436d6)

The links for all the integrations were pointing to the Elixir integration. This PR fixes that.