### PR TITLE
Terms of Service for Livebook Teams

### DIFF
--- a/src/pages/teams/pricing.astro
+++ b/src/pages/teams/pricing.astro
@@ -1,0 +1,1 @@
+At this moment, we only have the free pricing, for users who joined the free early access program.

--- a/src/pages/teams/terms.astro
+++ b/src/pages/teams/terms.astro
@@ -1,0 +1,970 @@
+---
+import Layout from "../../layouts/Layout.astro";
+---
+
+<Layout title="Privacy Policy">
+  <section id="intro">
+    <div class="m-auto max-w-7xl px-4 pt-10">
+      <div
+        class="m-auto max-w-4xl mb-20 bg-slate-50 rounded-xl px-5 sm:px-10 md:px-20 py-10"
+      >
+        <h1 class="text-gray-900 text-2xl md:text-3xl font-semibold">
+          Terms of Service
+        </h1>
+        <div class="text-gray-700 text-left space-y-7">
+          <div class="space-y-3">
+            <p class="mt-2 font-bold text-sm">Last Updated: April 09, 2024</p>
+            <p>
+              If you signed a separate Cover Page to access the Product with the
+              same account, and that agreement has not ended, the terms below do
+              not apply to you. Instead, your separate Cover Page applies to
+              your use of the Product.
+            </p>
+            <p>
+              This Agreement is between ELIXIR SERVICES AND SUPPORT and the
+              company or person accessing or using the Product. This Agreement
+              consists of:
+            </p>
+            <ul class="list-disc list-inside space-y-1">
+              <li>Cover Page: contains the Order Form and the Key Terms</li>
+              <li>
+                Standard Terms: the Common Paper <a
+                  href="https://commonpaper.com/standards/cloud-service-agreement/1.1"
+                  class="underline decoration-solid"
+                  >Cloud Service Agreement Standard Terms Version 1.1</a
+                >. A copy of those Standard Terms is also included in this page
+                for your convenience.
+              </li>
+            </ul>
+          </div>
+          <hr />
+          <div class="space-y-3">
+            <h2 class="font-bold text-2xl">Cover Page</h2>
+            <h3 class="font-bold text-lg">Order Form</h3>
+            <p>
+              <span class="font-bold">Cloud Service:</span> Livebook Teams is a cloud-based
+              software that allows you to deploy Livebook apps to your own server
+              infrastructure.
+            </p>
+            <p>
+              <span class="font-bold">Subscription Start Date:</span> The Effective
+              Date.
+            </p>
+            <p>
+              <span class="font-bold">Subscription Period:</span> 1 month(s).
+            </p>
+            <p>
+              <span class="font-bold">Non-Renewal Notice Period:</span> At least
+              30 days before the end of the current Subscription Period.
+            </p>
+            <p>
+              <span class="font-bold">Cloud Service Fees:</span> Section 5.2 of the
+              Standard Terms is replaced with: Certain parts of the Product have
+              different pricing plans, which are available at Provider's <a
+                href="/teams/pricing"
+                class="underline decoration-solid">pricing page</a
+              >. Within the Payment Period, Customer will pay Provider fees
+              based on the Product tier selected at the time of account creation
+              and Customer'is usage per Subscription Period. Provider may update
+              Product pricing by giving at least 30 days notice to Customer
+              (including by email or notification within the Product), and the
+              change will apply in the next Subscription Period.
+            </p>
+            <p>
+              <span class="font-bold">Payment Period:</span> 7 day(s) from date of
+              invoice.
+            </p>
+            <p>
+              <span class="font-bold">Invoice Period:</span> Monthly.
+            </p>
+            <h3 class="font-bold text-lg">Key Terms</h3>
+            <p>
+              <span class="font-bold">Customer:</span> The company or person who
+              accesses or uses the Product. If the person accepting this Agreement
+              is doing so on behalf of a company, all use of the word "Customer"
+              in the Agreement will mean that company.
+            </p>
+            <p>
+              <span class="font-bold">Provider:</span> Elixir Services and Support.
+            </p>
+            <p>
+              <span class="font-bold">Effective Date:</span> The date Customer first
+              accepts this Agreement.
+            </p>
+            <p>
+              <span class="font-bold">General Cap Amount:</span> The fees paid or
+              payable by Customer to provider in the 12 month period immediately
+              before the claim.
+            </p>
+            <p>
+              <span class="font-bold">Governing Law:</span> The laws of Poland.
+            </p>
+            <p>
+              <span class="font-bold">Chosen Courts:</span> Courts of Poland.
+            </p>
+            <p>
+              <span class="font-bold">Notice Address:</span>
+              <ul class="list-disc list-inside space-y">
+                <li>For Provider: notices@livebook.dev</li>
+                <li>For Customer: The main address on Customer's account</li>
+              </ul>
+            </p>
+          </div>
+          <hr />
+          <div class="space-y-3">
+            <h2 class="font-bold text-2xl">
+              Standar Terms (Cloud Service Agreement)
+            </h2>
+            <ol class="standard-terms">
+              <li>
+                <span class="clause-name">Service</span>
+                <ol>
+                  <li>
+                    <span class="sub-clause-name">Access and Use.</span> During the
+                    Subscription Period and subject to the Use Limitations, Customer
+                    may (a) access and use the Cloud Service; and (b) copy and use
+                    the included Software and Documentation only as needed to access
+                    and use the Cloud Service, in each case, for its internal business
+                    purposes and only if Customer complies with the terms of this
+                    Agreement.
+                  </li>
+                  <li>
+                    <span class="sub-clause-name">Service Level</span>. If there
+                    is an SLA and the Cloud Service does not meet the SLA,
+                    Provider will provide the remedies outlined in the SLA and
+                    will not be responsible for any other remedies. Any credits
+                    earned under the SLA will only apply to future invoices and
+                    expire if the Agreement ends. In any event, if the Cloud
+                    Service is temporarily unavailable for scheduled
+                    maintenance, for unscheduled emergency maintenance, or
+                    because of other causes beyond Provider's reasonable
+                    control, no SLA remedies will accrue. Provider will try to
+                    inform Customer before scheduled service disruptions through
+                    the Cloud Service or by email.
+                  </li>
+                  <li>
+                    <span class="sub-clause-name">Support.</span> During the Subscription
+                    Period, Provider will provide Technical Support as described
+                    in the Cover Page, if any.
+                  </li>
+                  <li>
+                    <span class="sub-clause-name">User Accounts.</span> Customer
+                    is responsible for all actions on Users' accounts and for Users'
+                    compliance with this Agreement. Customer and Users must protect
+                    the confidentiality of their passwords and login credentials.
+                    Customer will promptly notify Provider if it suspects or knows
+                    of any fraudulent activity with its accounts, passwords, or credentials,
+                    or if they become compromised.
+                  </li>
+                  <li>
+                    <span class="sub-clause-name">Affiliates.</span> If authorized
+                    in a Cover Page, individuals from Customer's Affiliates may access
+                    Customer's account as Users under Customer's Agreement and Customer
+                    will be responsible for its Affiliates' compliance with this
+                    Agreement. If a Customer Affiliate enters a separate Cover Page
+                    with Provider, the Customer's Affiliate creates a separate agreement
+                    between Provider and that Affiliate, where Provider's responsibility
+                    to the Affiliate is individual and separate from Customer and
+                    Customer is not responsible for its Affiliates' agreement.
+                  </li>
+                  <li>
+                    <span class="sub-clause-name">Feedback and Usage Data.</span
+                    > Customer may, but is not required to, give Provider Feedback,
+                    in which case Customer gives Feedback "AS IS". Provider may use
+                    all Feedback freely without any restriction or obligation. In
+                    addition, Provider may collect and analyze Usage Data, and Provider
+                    may freely use Usage Data to maintain, improve, and enhance Provider's
+                    products and services without restriction or obligation. However,
+                    Provider may only share Usage Data with others if the Usage Data
+                    is aggregated and does not identify Customer or Users.
+                  </li>
+                  <li>
+                    <span class="sub-clause-name">Customer Content.</span> Provider
+                    may copy, display, modify, and use Customer Content only as needed
+                    to provide and maintain the Product and related offerings. Customer
+                    is responsible for the accuracy and content of Customer Content.
+                  </li>
+                </ol>
+              </li>
+              <li>
+                <span class="clause-name">Restrictions & Obligations</span>
+                <ol>
+                  <li>
+                    <span class="sub-clause-name"
+                      >Restrictions on Customer.</span
+                    >
+                    <ol>
+                      <li>
+                        Except as expressly permitted by this Agreement,
+                        Customer will not (and will not allow any anyone else
+                        to): (i) reverse engineer, decompile, or attempt to
+                        discover any source code or underlying ideas or
+                        algorithms of the Product (except to the extent
+                        Applicable Laws prohibit this restriction); (ii)
+                        provide, sell, transfer, sublicense, lend, distribute,
+                        rent, or otherwise allow others to access or use the
+                        Product; (iii) remove any proprietary notices or labels;
+                        (iv) copy, modify, or create derivative works of the
+                        Product; (v) conduct security or vulnerability tests on,
+                        interfere with the operation of, cause performance
+                        degradation of, or circumvent access restrictions of the
+                        Product; (vi) access accounts, information, data, or
+                        portions of the Product to which Customer does not have
+                        explicit authorization; (vii) use the Product to develop
+                        a competing service or product; (viii) use the Product
+                        with any High Risk Activities or with activity
+                        prohibited by Applicable Laws; (ix) use the Product to
+                        obtain unauthorized access to anyone else's networks or
+                        equipment; or (x) upload, submit, or otherwise make
+                        available to the Product any Customer Content to which
+                        Customer and Users do not have the proper rights.
+                      </li>
+                      <li>
+                        Customer's use of the Product must comply with all
+                        Documentation and the Acceptable Use Policy, if any.
+                      </li>
+                    </ol>
+                  </li>
+                  <li>
+                    <span class="sub-clause-name">Suspension.</span> if Customer
+                    (a) has an outstanding, undisputed balance on its account for
+                    more than 30 days after the Payment Period; (b) breaches Section
+                    2.1 (Restrictions on Customer); or (c) uses the Product in violation
+                    of the Agreement or in a way that materially and negatively impacts
+                    the Product or others, then Provider may temporarily suspend
+                    Customer's access to the Product with or without notice. However,
+                    Provider will try to inform Customer before suspending Customer's
+                    account when practical. Provider will reinstate Customer's access
+                    to the Product only if Customer resolves the underlying issue.
+                  </li>
+                </ol>
+              </li>
+              <li>
+                <span class="clause-name">Professional Services</span><p>
+                  Provider will perform the Professional Services as detailed in
+                  a Cover Page, if any, and Customer will reasonably cooperate
+                  with Provider to allow the performance of Professional
+                  Services, including providing Customer Content as needed.
+                  Provider is not responsible for any inability to perform the
+                  Professional Services if Customer does not cooperate as
+                  reasonably requested.
+                </p>
+              </li>
+              <li>
+                <span class="clause-name">Privacy & Security</span><ol>
+                  <li>
+                    <span class="sub-clause-name">Personal Data.</span> Before submitting
+                    Personal Data governed by GDPR, Customer must enter into a data
+                    processing agreement with Provider. If the parties have a DPA,
+                    the terms of the DPA will control each party's rights and obligations
+                    as to Personal Data and the terms of the DPA will control in
+                    the event of any conflict with this Agreement.
+                  </li>
+                  <li>
+                    <span class="sub-clause-name">Prohibited Data.</span> Customer
+                    will not (and will not allow anyone else to) submit Prohibited
+                    Data to the Product unless authorized by the Cover Page.
+                  </li>
+                  <li>
+                    <span class="sub-clause-name">Security.</span> Provider will
+                    comply with the Security Policy, if any.
+                  </li>
+                </ol>
+              </li>
+              <li>
+                <span class="clause-name">Payments & Taxes</span>
+                <ol>
+                  <li>
+                    <span class="sub-clause-name">Fees and Invoices.</span> All fees
+                    are in U.S. Dollars and are exclusive of taxes. Except for the
+                    prorated refund of prepaid fees allowed with specific termination
+                    rights, fees are non-refundable. Provider will send invoices
+                    for fees applicable to the Product once per Invoice Period in
+                    advance starting on the Subscription Start Date. Invoices for
+                    Professional Services may be sent monthly during performance
+                    of the Professional Services unless the Cover Page includes a
+                    different cadence.
+                  </li>
+                  <li>
+                    <span class="sub-clause-name">Payment.</span> Customer will pay
+                    Provider the fees and taxes in each invoice in U.S. Dollars within
+                    the Payment Period.
+                  </li>
+                  <li>
+                    <span class="sub-clause-name">Taxes.</span> Customer is responsible
+                    for all duties, taxes, and levies that apply to fees, including
+                    sales, use, VAT, GST, or withholding, that Provider itemizes
+                    and includes in an invoice. However, Customer is not responsible
+                    for Provider's income taxes.
+                  </li>
+                  <li>
+                    <span class="sub-clause-name">Payment Dispute.</span> If Customer
+                    has a good-faith disagreement about the amounts charged on an
+                    invoice, Customer must notify Provider about the dispute during
+                    the Payment Period for the invoice and must pay all undisputed
+                    amounts on time. The parties will work together to resolve the
+                    dispute within 15 days after the end of the Payment Period. If
+                    no resolution is agreed, each party may pursue any remedies available
+                    under the Agreement or Applicable Laws.
+                  </li>
+                </ol>
+              </li>
+              <li>
+                <span class="clause-name">Term & Termination</span>
+                <ol>
+                  <li>
+                    <span class="sub-clause-name">Subscription Period.</span> Each
+                    Order Form will start on the Subscription Start Date, continue
+                    for the Subscription Period, and automatically renew for additional
+                    Subscription Periods unless one party gives notice of non-renewal
+                    to the other party before the Non-Renewal Notice Date.
+                  </li>
+                  <li>
+                    Agreement Term. This Agreement will start on the Effective
+                    Date and continue for the longer of one year or until all
+                    Subscription Periods have ended.
+                  </li>
+                  <li>
+                    <span class="sub-clause-name">Termination.</span> Either party
+                    may terminate this Agreement if the other party (a) fails to
+                    cure a material breach of the Agreement within 30 days after
+                    receiving notice of the breach; (b) materially breaches the Agreement
+                    in a manner that cannot be cured; (c) dissolves or stops conducting
+                    business without a successor; (d) makes an assignment for the
+                    benefit of creditors; or (e) becomes the debtor in insolvency,
+                    receivership, or bankruptcy proceedings that continue for more
+                    than 60 days. In addition, either party may terminate an affected
+                    Order Form if a Force Majeure Event prevents the Product from
+                    materially operating for 30 or more consecutive days, and Provider
+                    will pay to Customer a prorated refund of prepaid fees for the
+                    remainder of the Subscription Period. A party must notify the
+                    other of its reason for termination.
+                  </li>
+                  <li>
+                    <span class="sub-clause-name">Effect of Termination.</span> Termination
+                    of the Agreement will automatically terminate all Order Forms.
+                    Upon expiration or termination:
+                    <ol>
+                      <li>
+                        Customer will no longer have any right to use the
+                        Product, Technical Support, or Professional Services.
+                      </li>
+                      <li>
+                        Upon Customer's request, Provider will delete Customer
+                        Content within 60 days.
+                      </li>
+                      <li>
+                        Each Recipient will return or destroy Discloser's
+                        Confidential Information in its possession or control.
+                      </li>
+                      <li>
+                        Provider will submit a final invoice for all outstanding
+                        fees accrued before termination and Customer will pay
+                        the invoice according to Section 5 (Payment & Taxes).
+                      </li>
+                    </ol>
+                  </li>
+                  <li>
+                    <span class="sub-clause-name">Survival.</span>
+                    <ol>
+                      <li>
+                        The following sections will survive expiration or
+                        termination of the Agreement: Section 1.6 (Feedback and
+                        Usage Data), Section 2.1 (Restrictions on Customer),
+                        Section 5 (Payment & Taxes) for fees accrued or payable
+                        before expiration or termination, Section 6.4 (Effect of
+                        Termination), Section 6.5 (Survival), Section 7
+                        (Representations & Warranties), Section 8 (Disclaimer of
+                        Warranties), Section 9 (Limitation of Liability),
+                        Section 10 (Indemnification), Section 11 (Insurance) for
+                        the time period specified, Section 12 (Confidentiality),
+                        Section 13 (Reservation of Rights), Section 14 (General
+                        Terms), Section 15 (Definitions), and the portions of a
+                        Cover Page referenced by these sections.
+                      </li>
+                      <li>
+                        Each Recipient may retain Discloser's Confidential
+                        Information in accordance with its standard backup or
+                        record retention policies maintained in the ordinary
+                        course of business or as required by Applicable Laws, in
+                        which case Section 4 (Privacy & Security) and Section 12
+                        (Confidentiality) will continue to apply to retained
+                        Confidential Information.
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+              <li>
+                <span class="clause-name">Representation & Warranties</span>
+                <ol>
+                  <li>
+                    <span class="sub-clause-name">Mutual.</span> Each party represents
+                    and warrants to the other that: (a) it has the legal power and
+                    authority to enter into this Agreement; (b) it is duly organized,
+                    validly existing, and in good standing under the Applicable Laws
+                    of the jurisdiction of its origin; (c) it will comply with all
+                    Applicable Laws in performing its obligations or exercising its
+                    rights in this Agreement; and (d) it will comply with the Additional
+                    Warranties.
+                  </li>
+                  <li>
+                    <span class="sub-clause-name">From Customer.</span> Customer
+                    represents and warrants that it, all Users, and anyone submitting
+                    Customer Content each have and will continue to have all rights
+                    necessary to submit or make available Customer Content to the
+                    Product and to allow the use of Customer Content as described
+                    in the Agreement.
+                  </li>
+                  <li>
+                    <span class="sub-clause-name">From Provider.</span> Provider
+                    represents and warrants to Customer that (a) it will not materially
+                    reduce the general functionality of the Cloud Service during
+                    a Subscription Period; and (b) it will perform Professional Services
+                    in a competent and professional manner.
+                  </li>
+                  <li>
+                    <span class="sub-clause-name"
+                      >Provider Warranty Remedy.</span
+                    > If Provider breaches a warranty in Section 7.3, Customer must
+                    give Provider notice (with enough detail for Provider to understand
+                    or replicate the issue) within 45 days of discovering the issue.
+                    Within 45 days of receiving sufficient details of the warranty
+                    issue, Provider will attempt to restore the general functionality
+                    of the Cloud Service or reperform the Professional Services.
+                    If Provider cannot resolve the issue, Customer may terminate
+                    the affected Order Form and Provider will pay to Customer a prorated
+                    refund of prepaid fees for the remainder of the Subscription
+                    Period. Provider's restoration and reperformance obligations,
+                    and Customer's termination right, are Customer's only remedies
+                    if Provider does not meet the warranties in Section 7.3.
+                  </li>
+                </ol>
+              </li>
+              <li>
+                <span class="clause-name">Disclaimer of Warranties</span>
+                <p>
+                  Provider makes no guarantees that the Product will always be
+                  safe, secure, or error-free, or that it will function without
+                  disruptions, delays, or imperfections. The warranties in
+                  Section 7.3 do not apply to any misuse or unauthorized
+                  modification of the Product, nor to any product or service
+                  provided by anyone other than Provider. Except for the
+                  warranties in Section 7, Provider and Customer each disclaim
+                  all other warranties, whether express or implied, including
+                  the implied warranties of merchantability, fitness for a
+                  particular purpose, title, and non-infringement. These
+                  disclaimers apply to the maximum extent permitted by
+                  Applicable Laws.
+                </p>
+              </li>
+              <li>
+                <span class="clause-name">Limitation of Liability</span>
+                <ol>
+                  <li>
+                    <span class="sub-clause-name">Liability Caps</span>. If
+                    there are Increased Claims, each party's total cumulative
+                    liability for the Increased Claims arising out of or
+                    relating to this Agreement will not be more than the
+                    Increased Cap Amount. Each party's total cumulative
+                    liability for all other claims arising out of or relating to
+                    this Agreement will not be more than the General Cap Amount.
+                  </li>
+                  <li>
+                    <span class="sub-clause-name">Damages Waiver.</span> Each party's
+                    liability for any claim or liability arising out of or relating
+                    to this Agreement will be limited to the fullest extent permitted
+                    by Applicable Laws. Under no circumstances will either party
+                    be liable to the other for lost profits or revenues, or for consequential,
+                    special, indirect, exemplary, punitive, or incidental damages
+                    relating to this Agreement, even if the party is informed of
+                    the possibility of this type of damage in advance.
+                  </li>
+                  <li>
+                    <span class="sub-clause-name">Exceptions.</span> The liability
+                    caps in Section 9.1 and the damages waiver in Section 9.2 do
+                    not apply to any Unlimited Claims. The damages waiver in Section
+                    9.2 does not apply to any Increased Claims.
+                  </li>
+                </ol>
+              </li>
+              <li>
+                <span class="clause-name">Indemnification</span>
+                <ol>
+                  <li>
+                    <span class="sub-clause-name">Protection by Provider.</span>
+                    Provider will indemnify, defend, and hold harmless Customer from
+                    and against all Provider Covered Claims made by someone other
+                    than Customer, Customer's Affiliates, or Users, and all out-of-pocket
+                    damages, awards, settlements, costs, and expenses, including
+                    reasonable attorneys' fees and other legal expenses, that arise
+                    from the Provider Covered Claim.
+                  </li>
+                  <li>
+                    <span class="sub-clause-name">Protection by Customer.</span>
+                    Customer will indemnify, defend, and hold harmless Provider from
+                    and against all Customer Covered Claims made by someone other
+                    than Provider or its Affiliates, and all out-of-pocket damages,
+                    awards, settlements, costs, and expenses, including reasonable
+                    attorneys' fees and other legal expenses, that arise from the
+                    Customer Covered Claim.
+                  </li>
+                  <li>
+                    <span class="sub-clause-name">Procedure.</span> The Indemnifying
+                    Party's obligations in this section are contingent upon the Protected
+                    Party: (a) promptly notifying the Indemnifying Party of each
+                    Covered Claim for which it seeks protection; (b) providing reasonable
+                    assistance to the Indemnifying Party at the Indemnifying Party's
+                    expense; and (c) giving the Indemnifying Party sole control over
+                    the defense and settlement of each Covered Claim. A Protected
+                    Party may participate in a Covered Claim for which it seeks protection
+                    with its own attorneys only at its own expense. The Indemnifying
+                    Party may not agree to any settlement of a Covered Claim that
+                    contains an admission of fault or otherwise materially and adversely
+                    impacts the Protected Party without the prior written consent
+                    of the Protected Party.
+                  </li>
+                  <li>
+                    <span class="sub-clause-name">Changes to Product.</span> If required
+                    by settlement or court order, or if deemed reasonably necessary
+                    in response to a Provider Covered Claim, Provider may: (a) obtain
+                    the right for Customer to continue using the Product; (b) replace
+                    or modify the affected component of the Product without materially
+                    reducing the general functionality of the Product; or (c) if
+                    neither (a) nor (b) are reasonable, terminate the affected Order
+                    Form and issue a pro-rated refund of prepaid fees for the remainder
+                    of the Subscription Period.
+                  </li>
+                  <li>
+                    <span class="sub-clause-name">Exclusions.</span>
+                    <ol>
+                      <li>
+                        Provider's obligations as an Indemnifying Party will not
+                        apply to Provider Covered Claims that result from (i)
+                        modifications to the Product that were not authorized by
+                        Provider or that were made in compliance with Customer's
+                        instructions; (ii) unauthorized use of the Product,
+                        including use in violation of this Agreement; (iii) use
+                        of the Product in combination with items not provided by
+                        Provider; or (iv) use of an old version of the Product
+                        where a newer release would avoid the Provider Covered
+                        Claim.
+                      </li>
+                      <li>
+                        Customer's obligations as an Indemnifying Party will not
+                        apply to Customer Covered Claims that result from the
+                        unauthorized use of the Customer Content, including use
+                        in violation of this Agreement.
+                      </li>
+                    </ol>
+                  </li>
+                  <li>
+                    <span class="sub-clause-name">Exclusive Remedy.</span> This Section
+                    10 (Indemnification), together with any termination rights, describes
+                    each Protected Party's exclusive remedy and each Indemnifying
+                    Party's entire liability for a Covered Claim.
+                  </li>
+                </ol>
+                <li>
+                  <span class="clause-name">Insurance</span>
+                  <p>
+                    During the Subscription Period and for six months after,
+                    Provider will carry commercial insurance policies with
+                    coverage limits that meet the Insurance Minimums, if any.
+                    Upon request, Provider will give Customer a certificate of
+                    insurance evidencing its insurance policies that meet the
+                    Insurance Minimums. Provider's insurance policies will not
+                    be considered as evidence of Provider's liability.
+                  </p>
+                </li>
+                <li>
+                  <span class="clause-name">Confidentiality</span>
+                  <ol>
+                    <li>
+                      <span class="sub-clause-name"
+                        >Non-Use and Non-Disclosure.</span
+                      > Unless otherwise authorized in the Agreement, Recipient will
+                      (a) only use Discloser's Confidential Information to fulfill
+                      its obligations or exercise its rights under this Agreement;
+                      and (b) not disclose Discloser's Confidential Information to
+                      anyone else. In addition, Recipient will protect Discloser's
+                      Confidential Information using at least the same protections
+                      Recipient uses for its own similar information but no less
+                      than a reasonable standard of care.
+                    </li>
+                    <li>
+                      <span class="sub-clause-name">Exclusions.</span> Confidential
+                      Information does not include information that (a) Recipient
+                      knew without any obligation of confidentiality before disclosure
+                      by Discloser; (b) is or becomes publicly known and generally
+                      available through no fault of Recipient; (c) Recipient receives
+                      under no obligation of confidentiality from someone else who
+                      is authorized to make the disclosure; or (d) Recipient independently
+                      developed without use of or reference to Discloser's Confidential
+                      Information.
+                    </li>
+                    <li>
+                      <span class="sub-clause-name">Required Disclosures.</span>
+                      Recipient may disclose Discloser's Confidential Information
+                      to the extent required by Applicable Laws if, unless prohibited
+                      by Applicable Laws, Recipient provides the Discloser reasonable
+                      advance notice of the required disclosure and reasonably cooperates,
+                      at the Discloser's expense, with the Discloser's efforts to
+                      obtain confidential treatment for the Confidential Information.
+                    </li>
+                    <li>
+                      <span class="sub-clause-name">Permitted Disclosures.</span
+                      > Recipient may disclose Discloser's Confidential Information
+                      to Users, employees, advisors, contractors, and representatives
+                      who each have a need to know the Confidential Information,
+                      but only if the person or entity is bound by confidentiality
+                      obligations at least as protective as those in this Section
+                      12 and Recipient remains responsible for everyone's compliance
+                      with the terms of this Section 12.
+                    </li>
+                  </ol>
+                </li>
+                <li>
+                  <span class="clause-name">Reservation of Rights</span>
+                  <p>
+                    Except for the limited license to copy and use Software and
+                    Documentation in Section 1.1 (Access and Use), Provider
+                    retains all right, title, and interest in and to the
+                    Product, whether developed before or after the Effective
+                    Date. Except for the limited rights in Section 1.7 (Customer
+                    Content), Customer retains all right, title, and interest in
+                    and to the Customer Content.
+                  </p>
+                </li>
+                <li>
+                  <span class="clause-name">General Terms</span>
+                  <ol>
+                    <li>
+                      <span class="sub-clause-name">Entire Agreement.</span> This
+                      Agreement is the only agreement between the parties about its
+                      subject and this Agreement supersedes all prior or contemporaneous
+                      statements (whether in writing or not) about its subject. Provider
+                      expressly rejects any terms included in Customer's purchase
+                      order or similar document, which may only be used for accounting
+                      or administrative purposes.
+                    </li>
+                    <li>
+                      <span class="sub-clause-name"
+                        >Modifications, Severability, and Waiver.</span
+                      > Any waiver, modification, or change to the Agreement must
+                      be in writing and signed or electronically accepted by each
+                      party. However, Provider may update Technical Support, the
+                      SLA, the Security Policy, or the Acceptable Use Policy by giving
+                      Customer 30 days prior notice. During the 30-day notice period,
+                      Customer may terminate the Agreement or affected Order Form
+                      upon notice if the update is a material reduction from the
+                      prior version and Provider cannot reasonably restore the prior
+                      version or a comparable alternative. If any term of this Agreement
+                      is determined to be invalid or unenforceable by a relevant
+                      court or governing body, the remaining terms of this Agreement
+                      will remain in full force and effect. The failure of a party
+                      to enforce a term or to exercise an option or right in this
+                      Agreement will not constitute a waiver by that party of the
+                      term, option, or right.
+                    </li>
+                    <li>
+                      <span class="sub-clause-name"
+                        >Governing Law and Chosen Courts.</span
+                      > The Governing Law will govern all interpretations and disputes
+                      about this Agreement, without regard to its conflict of laws
+                      provisions. The parties will bring any legal suit, action,
+                      or proceeding about this Agreement in the Chosen Courts and
+                      each party irrevocably submits to the exclusive jurisdiction
+                      of the Chosen Courts.
+                    </li>
+                    <li>
+                      <span class="sub-clause-name">Injunctive Relief.</span> Despite
+                      Section 14.3 (Governing Law and Chosen Courts), a breach of
+                      Section 12 (Confidentiality) or the violation of a party's
+                      intellectual property rights may cause irreparable harm for
+                      which monetary damages cannot adequately compensate. As a result,
+                      upon the actual or threatened breach of Section 12 (Confidentiality)
+                      or violation of a party's intellectual property rights, the
+                      non-breaching or non-violating party may seek appropriate equitable
+                      relief, including an injunction, in any court of competent
+                      jurisdiction without the need to post a bond and without limiting
+                      its other rights or remedies.
+                    </li>
+                    <li>
+                      <span class="sub-clause-name"
+                        >Non-Exhaustive Remedies.</span
+                      > Except where the Agreement provides for an exclusive remedy,
+                      seeking or exercising a remedy does not limit the other rights
+                      or remedies available to a party.
+                    </li>
+                    <li>
+                      <span class="sub-clause-name"> Assignment.</span> Neither party
+                      may assign any rights or obligations under this Agreement without
+                      the prior written consent of the other party. However, either
+                      party may assign this Agreement upon notice if the assigning
+                      party undergoes a merger, change of control, reorganization,
+                      or sale of all or substantially all its equity, business, or
+                      assets to which this Agreement relates. Any attempted but non-permitted
+                      assignment is void. This Agreement will be binding upon and
+                      inure to the benefit of the parties and their permitted successors
+                      and assigns.
+                    </li>
+                    <li>
+                      <span class="sub-clause-name">No Publicity.</span> Neither
+                      party may publicly announce the existence of this Agreement
+                      without the prior written approval of the other party.
+                    </li>
+                    <li>
+                      <span class="sub-clause-name">Notices.</span> Any notice, request,
+                      or approval about the Agreement must be in writing and sent
+                      to the Notice Address. Notices will be deemed given (a) upon
+                      confirmed delivery if by email, registered or certified mail,
+                      or personal delivery; or (b) two days after mailing if by overnight
+                      commercial delivery.
+                    </li>
+                    <li>
+                      <span class="sub-clause-name"
+                        >Independent Contractors.</span
+                      > The parties are independent contractors, not agents, partners,
+                      or joint venturers. Neither party is authorized to bind the
+                      other to any liability or obligation.
+                    </li>
+                    <li>
+                      <span class="sub-clause-name"
+                        >No Third-Party Beneficiary.</span
+                      > There are no third-party beneficiaries of this Agreement.
+                    </li>
+                    <li>
+                      <span class="sub-clause-name">Force Majeure.</span> Neither
+                      party will be liable for a delay or failure to perform its
+                      obligations of this Agreement if caused by a Force Majeure
+                      Event. However, this section does not excuse Customer's obligations
+                      to pay fees.
+                    </li>
+                    <li>
+                      <span class="sub-clause-name">Export Controls.</span> Customer
+                      may not remove or export from the United States or allow the
+                      export or re-export of the Product or any related technology
+                      or materials in violation of any restrictions, laws, or regulations
+                      of the United States Department of Commerce, the United States
+                      Department of Treasury Office of Foreign Assets Control, or
+                      any other United States or foreign agency or authority.
+                    </li>
+                    <li>
+                      <span class="sub-clause-name">Government Rights.</span> The
+                      Cloud Service and Software are deemed "commercial items" or
+                      "commercial computer software" according to FAR section 12.212
+                      and DFAR section 227.7202, and the Documentation is "commercial
+                      computer software documentation" according to DFAR section
+                      252.227-7014(a)(1) and (5). Any use, modification, reproduction,
+                      release, performance, display, or disclosure of the Product
+                      by the U.S. Government will be governed solely by the terms
+                      of this Agreement and all other use is prohibited.
+                    </li>
+                    <li>
+                      <span class="sub-clause-name">Anti-Bribery.</span> Neither
+                      party will take any action that would be a violation of any
+                      Applicable Laws that prohibit the offering, giving, promising
+                      to offer or give, or receiving, directly or indirectly, money
+                      or anything of value to any third party to assist Provider
+                      or Customer in retaining or obtaining business. Examples of
+                      these kinds of laws include the U.S. Foreign Corrupt Practices
+                      Act and the UK Bribery Act 2010.
+                    </li>
+                    <li>
+                      <span class="sub-clause-name"
+                        >Titles and Interpretation.</span
+                      > Section titles are for convenience and reference only. All
+                      uses of "including" and similar phrases are non-exhaustive
+                      and without limitation. The United Nations Convention for the
+                      International Sale of Goods and the Uniform Computer Information
+                      Transaction Act do not apply to this Agreement.
+                    </li>
+                    <li>
+                      <span class="sub-clause-name">Signature.</span> This Agreement
+                      may be signed in counterparts, including by electronic copies
+                      or acceptance mechanism. Each copy will be deemed an original
+                      and all copies, when taken together, will be the same agreement.
+                    </li>
+                  </ol>
+                </li>
+                <li>
+                  <span class="clause-name">Definitions</span>
+                  <ol>
+                    <li>
+                      <span class="font-semibold">"Affiliate"</span> means an entity
+                      that, directly or indirectly, controls, is under the control
+                      of, or is under common control with a party, where control
+                      means having more than fifty percent (50%) of the voting stock
+                      or other ownership interest.
+                    </li>
+                    <li>
+                      <span class="font-semibold">"Agreement"</span> means these
+                      Standard Terms, together with the Cover Pages between Provider
+                      and Customer that include or reference a single set of Key
+                      Terms and the policies and documents referenced in or attached
+                      to those Cover Pages.
+                    </li>
+                    <li>
+                      <span class="font-semibold">"Applicable Data Protection Laws"</span> means the Applicable
+                      Laws that govern how the Cloud Service may process or use
+                      an individual's personal information, personal data,
+                      personally identifiable information, or other similar
+                      term.
+                    </li>
+                    <li>
+                      <span class="font-semibold">"Applicable Laws"</span> means the laws, rules, regulations,
+                      court orders, and other binding requirements of a relevant
+                      government authority that apply to or govern Provider or
+                      Customer.
+                    </li>
+                    <li>
+                      <span class="font-semibold">"Cloud Service"</span> means the product described in an Order
+                      Form.
+                    </li>
+                    <li>
+                      <span class="font-semibold">"Confidential Information"</span> means information in any form
+                      disclosed by or on behalf of a Discloser, including before
+                      the Effective Date, to a Recipient in connection with this
+                      Agreement that (a) the Discloser identifies as
+                      "confidential", "proprietary", or the like; or (b) should
+                      be reasonably understood as confidential or proprietary
+                      due to its nature and the circumstances of its disclosure.
+                      Confidential Information includes the existence of this
+                      Agreement and the information on each Cover Page.
+                      Customer's Confidential Information includes non-public
+                      Customer Content and Provider's Confidential Information
+                      includes non-public information about the Product.
+                    </li>
+                    <li>
+                      <span class="font-semibold">"Cover Page"</span> means a document that is signed or
+                      electronically accepted by the parties that incorporates
+                      these Standard Terms, identifies Provider and Customer,
+                      and may include an Order Form, Key Terms, or both.
+                    </li>
+                    <li>
+                      <span class="font-semibold">"Covered Claim"</span> means either a Provider Covered Claim or
+                      Customer Covered Claim.
+                    </li>
+                    <li>
+                      <span class="font-semibold">"Customer Content"</span> means data, information, or materials
+                      submitted by or on behalf of Customer or Users to the
+                      Product, but excludes Feedback.
+                    </li>
+                    <li>
+                      <span class="font-semibold">"Discloser"</span> means a party to this Agreement when the party
+                      is providing or disclosing Confidential Information to the
+                      other party.
+                    </li>
+                    <li>
+                      <span class="font-semibold">"Documentation"</span> means the usage manuals and instructional
+                      materials for the Cloud Service or Software that are made
+                      available by Provider.
+                    </li>
+                    <li>
+                      <span class="font-semibold">"Feedback"</span> means suggestions, feedback, or comments about
+                      the Product or related offerings.
+                    </li>
+                    <li>
+                      <span class="font-semibold">"Force Majeure Event"</span> means an unforeseen event outside a
+                      party's reasonable control where the affected party took
+                      reasonable measures to avoid or mitigate the impacts of
+                      the event. Examples of these kinds of events include
+                      unpredicted natural disaster like a major earthquake, war,
+                      pandemic, riot, act of terrorism, or public utility or
+                      internet failure.
+                    </li>
+                    <li>
+                      <span class="font-semibold">"GDPR"</span> means European Union Regulation 2016/679 as
+                      implemented by local law in the relevant European Union
+                      member nation, and by section 3 of the United Kingdom's
+                      European Union (Withdrawal) Act of 2018 in the United
+                      Kingdom.
+                    </li>
+                    <li>
+                      <span class="font-semibold">"High Risk Activity"</span> means any situation where the use or
+                      failure of the Product could be reasonably expected to
+                      lead to death, bodily injury, or environmental damage.
+                      Examples include full or partial autonomous vehicle
+                      technology, medical life-support technology, emergency
+                      response services, nuclear facilities operation, and air
+                      traffic control.
+                    </li>
+                    <li>
+                      <span class="font-semibold">"Indemnifying Party"</span> means a party to this Agreement when
+                      the party is providing protection for a particular Covered
+                      Claim.
+                    </li>
+                    <li>
+                      <span class="font-semibold">"Key Terms"</span> means the portion of a Cover Page that
+                      includes the key legal details and definitions for this
+                      Agreement that are not defined in the Standard Terms. The
+                      Key Terms may include details about Covered Claims, set
+                      the Governing Law, or contain other details about this
+                      Agreement.
+                    </li>
+                    <li>
+                      <span class="font-semibold">"Order Form"</span> means the portion of a Cover Page that
+                      includes the key business details and definitions for this
+                      Agreement that are not defined in the Standard Terms. An
+                      Order Form may include details about the level of access
+                      and use granted to the Cloud Service, nature and timing of
+                      Professional Services, extent of Technical Support, or
+                      other details about the Product.
+                    </li>
+                    <li>
+                      <span class="font-semibold">"Personal Data"</span> will have the meaning(s) set forth in the
+                      Applicable Data Protection Laws for personal information,
+                      personal data, personally identifiable information, or
+                      other similar term.
+                    </li>
+                    <li>
+                      <span class="font-semibold">"Product"</span> means the Cloud Service, Software, and
+                      Documentation.
+                    </li>
+                    <li>
+                      <span class="font-semibold">"Prohibited Data"</span> means (a) patient, medical, or other
+                      protected health information regulated by the Health
+                      Insurance Portability and Accountability Act; (b) credit,
+                      debit, bank account, or other financial account numbers;
+                      (c) social security numbers, driver's license numbers, or
+                      other unique and private government ID numbers; (d)
+                      special categories of data as defined in the GDPR; and (e)
+                      other similar categories of sensitive information as set
+                      forth in the Applicable Data Protection Laws.
+                    </li>
+                    <li>
+                      <span class="font-semibold">"Protected Party"</span> means a party to this Agreement when the
+                      party is receiving the benefit of protection for a
+                      particular Covered Claim.
+                    </li>
+                    <li>
+                      <span class="font-semibold">"Recipient"</span> means a party to this Agreement when the party
+                      receives Confidential Information from the other party.
+                    </li>
+                    <li>
+                      <span class="font-semibold">"Software"</span> means the client-side software or applications
+                      made available by Provider for Customer to install,
+                      download (whether onto a machine or in a browser), or
+                      execute as part of the Product.
+                    </li>
+                    <li>
+                      <span class="font-semibold">"Usage Data"</span> means data and information about the
+                      provision, use, and performance of the Product and related
+                      offerings based on Customer's or User's use of the
+                      Product.
+                    </li>
+                    <li>
+                      <span class="font-semibold">"User"</span> means any individual who uses the Product on
+                      Customer's behalf or through Customer's account.
+                    </li>
+                  </ol>
+                </li>
+              </li>
+            </ol>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</Layout>

--- a/src/pages/teams/terms.astro
+++ b/src/pages/teams/terms.astro
@@ -2,16 +2,16 @@
 import Layout from "../../layouts/Layout.astro";
 ---
 
-<Layout title="Privacy Policy">
-  <section id="intro">
+<Layout title="Terms of Service" isDarkMode={true} displaySponsors={false}>
+  <section class="bg-gray-900 text-gray-300">
     <div class="m-auto max-w-7xl px-4 pt-10">
       <div
-        class="m-auto max-w-4xl mb-20 bg-slate-50 rounded-xl px-5 sm:px-10 md:px-20 py-10"
+        class="m-auto max-w-4xl bg-gray-800 rounded-xl px-5 sm:px-10 md:px-20 py-10"
       >
-        <h1 class="text-gray-900 text-2xl md:text-3xl font-semibold">
+        <h1 class="text-2xl md:text-3xl font-semibold text-gray-200">
           Terms of Service
         </h1>
-        <div class="text-gray-700 text-left space-y-7">
+        <div class="text-left space-y-7">
           <div class="space-y-3">
             <p class="mt-2 font-bold text-sm">Last Updated: April 09, 2024</p>
             <p class="italic">
@@ -50,12 +50,12 @@ import Layout from "../../layouts/Layout.astro";
         </div>
         <hr class="my-8" />
         <!-- Cover Page -->
-        <div class="text-gray-700 space-y-3">
-          <h2 class="font-bold text-2xl">Cover Page</h2>
+        <div class="space-y-3">
+          <h2 class="font-bold text-2xl text-gray-200">Cover Page</h2>
           <div class="space-y-6">
             <!-- Order Form -->
             <div>
-              <h3 class="font-bold text-lg mb-4">Order Form</h3>
+              <h3 class="font-bold text-lg mb-4 text-gray-200">Order Form</h3>
               <div class="pl-6 space-y-4">
                 <p>
                   <span class="font-semibold">Cloud Service:</span> Livebook Teams
@@ -98,7 +98,7 @@ import Layout from "../../layouts/Layout.astro";
             </div>
             <!-- Key Terms -->
             <div>
-              <h3 class="font-bold text-lg mb-4">Key Terms</h3>
+              <h3 class="font-bold text-lg mb-4 text-gray-200">Key Terms</h3>
               <div class="pl-6 space-y-4">
                 <p>
                   <span class="font-semibold">Customer:</span> The company or person
@@ -140,8 +140,8 @@ import Layout from "../../layouts/Layout.astro";
         </div>
         <hr class="my-8" />
         <!-- Standard Terms -->
-        <div class="text-gray-700 space-y-3">
-          <h2 class="font-bold text-2xl">
+        <div class="space-y-3">
+          <h2 class="font-bold text-2xl text-gray-200">
             Standard Terms (Cloud Service Agreement)
           </h2>
           <ol

--- a/src/pages/teams/terms.astro
+++ b/src/pages/teams/terms.astro
@@ -14,6 +14,16 @@ import Layout from "../../layouts/Layout.astro";
         <div class="text-gray-700 text-left space-y-7">
           <div class="space-y-3">
             <p class="mt-2 font-bold text-sm">Last Updated: April 09, 2024</p>
+            <p class="italic">
+              <span class="font-semibold">Note:</span> These Terms of Service apply
+              solely to Livebook Teams, our Cloud Service. They do not apply to <a
+                href="https://github.com/livebook-dev/livebook"
+                class="underline decoration-solid">Livebook</a
+              >, the free and open-source software, which can be downloaded and
+              self-hosted independently, and has its own software license. If
+              you're only using Livebook without Livebook Teams, these terms do
+              not apply to you.
+            </p>
             <p>
               If you signed a separate Cover Page to access the Product with the
               same account, and that agreement has not ended, the terms below do

--- a/src/pages/teams/terms.astro
+++ b/src/pages/teams/terms.astro
@@ -37,932 +37,1166 @@ import Layout from "../../layouts/Layout.astro";
               </li>
             </ul>
           </div>
-          <hr />
-          <div class="space-y-3">
-            <h2 class="font-bold text-2xl">Cover Page</h2>
-            <h3 class="font-bold text-lg">Order Form</h3>
-            <p>
-              <span class="font-bold">Cloud Service:</span> Livebook Teams is a cloud-based
-              software that allows you to deploy Livebook apps to your own server
-              infrastructure.
-            </p>
-            <p>
-              <span class="font-bold">Subscription Start Date:</span> The Effective
-              Date.
-            </p>
-            <p>
-              <span class="font-bold">Subscription Period:</span> 1 month(s).
-            </p>
-            <p>
-              <span class="font-bold">Non-Renewal Notice Period:</span> At least
-              30 days before the end of the current Subscription Period.
-            </p>
-            <p>
-              <span class="font-bold">Cloud Service Fees:</span> Section 5.2 of the
-              Standard Terms is replaced with: Certain parts of the Product have
-              different pricing plans, which are available at Provider's <a
-                href="/teams/pricing"
-                class="underline decoration-solid">pricing page</a
-              >. Within the Payment Period, Customer will pay Provider fees
-              based on the Product tier selected at the time of account creation
-              and Customer'is usage per Subscription Period. Provider may update
-              Product pricing by giving at least 30 days notice to Customer
-              (including by email or notification within the Product), and the
-              change will apply in the next Subscription Period.
-            </p>
-            <p>
-              <span class="font-bold">Payment Period:</span> 7 day(s) from date of
-              invoice.
-            </p>
-            <p>
-              <span class="font-bold">Invoice Period:</span> Monthly.
-            </p>
-            <h3 class="font-bold text-lg">Key Terms</h3>
-            <p>
-              <span class="font-bold">Customer:</span> The company or person who
-              accesses or uses the Product. If the person accepting this Agreement
-              is doing so on behalf of a company, all use of the word "Customer"
-              in the Agreement will mean that company.
-            </p>
-            <p>
-              <span class="font-bold">Provider:</span> Elixir Services and Support.
-            </p>
-            <p>
-              <span class="font-bold">Effective Date:</span> The date Customer first
-              accepts this Agreement.
-            </p>
-            <p>
-              <span class="font-bold">General Cap Amount:</span> The fees paid or
-              payable by Customer to provider in the 12 month period immediately
-              before the claim.
-            </p>
-            <p>
-              <span class="font-bold">Governing Law:</span> The laws of Poland.
-            </p>
-            <p>
-              <span class="font-bold">Chosen Courts:</span> Courts of Poland.
-            </p>
-            <p>
-              <span class="font-bold">Notice Address:</span>
-              <ul class="list-disc list-inside space-y">
-                <li>For Provider: notices@livebook.dev</li>
-                <li>For Customer: The main address on Customer's account</li>
-              </ul>
-            </p>
-          </div>
-          <hr />
-          <div class="space-y-3">
-            <h2 class="font-bold text-2xl">
-              Standar Terms (Cloud Service Agreement)
-            </h2>
-            <ol class="standard-terms">
-              <li>
-                <span class="clause-name">Service</span>
-                <ol>
-                  <li>
-                    <span class="sub-clause-name">Access and Use.</span> During the
-                    Subscription Period and subject to the Use Limitations, Customer
-                    may (a) access and use the Cloud Service; and (b) copy and use
-                    the included Software and Documentation only as needed to access
-                    and use the Cloud Service, in each case, for its internal business
-                    purposes and only if Customer complies with the terms of this
-                    Agreement.
-                  </li>
-                  <li>
-                    <span class="sub-clause-name">Service Level</span>. If there
-                    is an SLA and the Cloud Service does not meet the SLA,
-                    Provider will provide the remedies outlined in the SLA and
-                    will not be responsible for any other remedies. Any credits
-                    earned under the SLA will only apply to future invoices and
-                    expire if the Agreement ends. In any event, if the Cloud
-                    Service is temporarily unavailable for scheduled
-                    maintenance, for unscheduled emergency maintenance, or
-                    because of other causes beyond Provider's reasonable
-                    control, no SLA remedies will accrue. Provider will try to
-                    inform Customer before scheduled service disruptions through
-                    the Cloud Service or by email.
-                  </li>
-                  <li>
-                    <span class="sub-clause-name">Support.</span> During the Subscription
-                    Period, Provider will provide Technical Support as described
-                    in the Cover Page, if any.
-                  </li>
-                  <li>
-                    <span class="sub-clause-name">User Accounts.</span> Customer
-                    is responsible for all actions on Users' accounts and for Users'
-                    compliance with this Agreement. Customer and Users must protect
-                    the confidentiality of their passwords and login credentials.
-                    Customer will promptly notify Provider if it suspects or knows
-                    of any fraudulent activity with its accounts, passwords, or credentials,
-                    or if they become compromised.
-                  </li>
-                  <li>
-                    <span class="sub-clause-name">Affiliates.</span> If authorized
-                    in a Cover Page, individuals from Customer's Affiliates may access
-                    Customer's account as Users under Customer's Agreement and Customer
-                    will be responsible for its Affiliates' compliance with this
-                    Agreement. If a Customer Affiliate enters a separate Cover Page
-                    with Provider, the Customer's Affiliate creates a separate agreement
-                    between Provider and that Affiliate, where Provider's responsibility
-                    to the Affiliate is individual and separate from Customer and
-                    Customer is not responsible for its Affiliates' agreement.
-                  </li>
-                  <li>
-                    <span class="sub-clause-name">Feedback and Usage Data.</span
-                    > Customer may, but is not required to, give Provider Feedback,
-                    in which case Customer gives Feedback "AS IS". Provider may use
-                    all Feedback freely without any restriction or obligation. In
-                    addition, Provider may collect and analyze Usage Data, and Provider
-                    may freely use Usage Data to maintain, improve, and enhance Provider's
-                    products and services without restriction or obligation. However,
-                    Provider may only share Usage Data with others if the Usage Data
-                    is aggregated and does not identify Customer or Users.
-                  </li>
-                  <li>
-                    <span class="sub-clause-name">Customer Content.</span> Provider
-                    may copy, display, modify, and use Customer Content only as needed
-                    to provide and maintain the Product and related offerings. Customer
-                    is responsible for the accuracy and content of Customer Content.
-                  </li>
-                </ol>
-              </li>
-              <li>
-                <span class="clause-name">Restrictions & Obligations</span>
-                <ol>
-                  <li>
-                    <span class="sub-clause-name"
-                      >Restrictions on Customer.</span
-                    >
-                    <ol>
-                      <li>
-                        Except as expressly permitted by this Agreement,
-                        Customer will not (and will not allow any anyone else
-                        to): (i) reverse engineer, decompile, or attempt to
-                        discover any source code or underlying ideas or
-                        algorithms of the Product (except to the extent
-                        Applicable Laws prohibit this restriction); (ii)
-                        provide, sell, transfer, sublicense, lend, distribute,
-                        rent, or otherwise allow others to access or use the
-                        Product; (iii) remove any proprietary notices or labels;
-                        (iv) copy, modify, or create derivative works of the
-                        Product; (v) conduct security or vulnerability tests on,
-                        interfere with the operation of, cause performance
-                        degradation of, or circumvent access restrictions of the
-                        Product; (vi) access accounts, information, data, or
-                        portions of the Product to which Customer does not have
-                        explicit authorization; (vii) use the Product to develop
-                        a competing service or product; (viii) use the Product
-                        with any High Risk Activities or with activity
-                        prohibited by Applicable Laws; (ix) use the Product to
-                        obtain unauthorized access to anyone else's networks or
-                        equipment; or (x) upload, submit, or otherwise make
-                        available to the Product any Customer Content to which
-                        Customer and Users do not have the proper rights.
-                      </li>
-                      <li>
-                        Customer's use of the Product must comply with all
-                        Documentation and the Acceptable Use Policy, if any.
-                      </li>
-                    </ol>
-                  </li>
-                  <li>
-                    <span class="sub-clause-name">Suspension.</span> if Customer
-                    (a) has an outstanding, undisputed balance on its account for
-                    more than 30 days after the Payment Period; (b) breaches Section
-                    2.1 (Restrictions on Customer); or (c) uses the Product in violation
-                    of the Agreement or in a way that materially and negatively impacts
-                    the Product or others, then Provider may temporarily suspend
-                    Customer's access to the Product with or without notice. However,
-                    Provider will try to inform Customer before suspending Customer's
-                    account when practical. Provider will reinstate Customer's access
-                    to the Product only if Customer resolves the underlying issue.
-                  </li>
-                </ol>
-              </li>
-              <li>
-                <span class="clause-name">Professional Services</span><p>
-                  Provider will perform the Professional Services as detailed in
-                  a Cover Page, if any, and Customer will reasonably cooperate
-                  with Provider to allow the performance of Professional
-                  Services, including providing Customer Content as needed.
-                  Provider is not responsible for any inability to perform the
-                  Professional Services if Customer does not cooperate as
-                  reasonably requested.
-                </p>
-              </li>
-              <li>
-                <span class="clause-name">Privacy & Security</span><ol>
-                  <li>
-                    <span class="sub-clause-name">Personal Data.</span> Before submitting
-                    Personal Data governed by GDPR, Customer must enter into a data
-                    processing agreement with Provider. If the parties have a DPA,
-                    the terms of the DPA will control each party's rights and obligations
-                    as to Personal Data and the terms of the DPA will control in
-                    the event of any conflict with this Agreement.
-                  </li>
-                  <li>
-                    <span class="sub-clause-name">Prohibited Data.</span> Customer
-                    will not (and will not allow anyone else to) submit Prohibited
-                    Data to the Product unless authorized by the Cover Page.
-                  </li>
-                  <li>
-                    <span class="sub-clause-name">Security.</span> Provider will
-                    comply with the Security Policy, if any.
-                  </li>
-                </ol>
-              </li>
-              <li>
-                <span class="clause-name">Payments & Taxes</span>
-                <ol>
-                  <li>
-                    <span class="sub-clause-name">Fees and Invoices.</span> All fees
-                    are in U.S. Dollars and are exclusive of taxes. Except for the
-                    prorated refund of prepaid fees allowed with specific termination
-                    rights, fees are non-refundable. Provider will send invoices
-                    for fees applicable to the Product once per Invoice Period in
-                    advance starting on the Subscription Start Date. Invoices for
-                    Professional Services may be sent monthly during performance
-                    of the Professional Services unless the Cover Page includes a
-                    different cadence.
-                  </li>
-                  <li>
-                    <span class="sub-clause-name">Payment.</span> Customer will pay
-                    Provider the fees and taxes in each invoice in U.S. Dollars within
-                    the Payment Period.
-                  </li>
-                  <li>
-                    <span class="sub-clause-name">Taxes.</span> Customer is responsible
-                    for all duties, taxes, and levies that apply to fees, including
-                    sales, use, VAT, GST, or withholding, that Provider itemizes
-                    and includes in an invoice. However, Customer is not responsible
-                    for Provider's income taxes.
-                  </li>
-                  <li>
-                    <span class="sub-clause-name">Payment Dispute.</span> If Customer
-                    has a good-faith disagreement about the amounts charged on an
-                    invoice, Customer must notify Provider about the dispute during
-                    the Payment Period for the invoice and must pay all undisputed
-                    amounts on time. The parties will work together to resolve the
-                    dispute within 15 days after the end of the Payment Period. If
-                    no resolution is agreed, each party may pursue any remedies available
-                    under the Agreement or Applicable Laws.
-                  </li>
-                </ol>
-              </li>
-              <li>
-                <span class="clause-name">Term & Termination</span>
-                <ol>
-                  <li>
-                    <span class="sub-clause-name">Subscription Period.</span> Each
-                    Order Form will start on the Subscription Start Date, continue
-                    for the Subscription Period, and automatically renew for additional
-                    Subscription Periods unless one party gives notice of non-renewal
-                    to the other party before the Non-Renewal Notice Date.
-                  </li>
-                  <li>
-                    Agreement Term. This Agreement will start on the Effective
-                    Date and continue for the longer of one year or until all
-                    Subscription Periods have ended.
-                  </li>
-                  <li>
-                    <span class="sub-clause-name">Termination.</span> Either party
-                    may terminate this Agreement if the other party (a) fails to
-                    cure a material breach of the Agreement within 30 days after
-                    receiving notice of the breach; (b) materially breaches the Agreement
-                    in a manner that cannot be cured; (c) dissolves or stops conducting
-                    business without a successor; (d) makes an assignment for the
-                    benefit of creditors; or (e) becomes the debtor in insolvency,
-                    receivership, or bankruptcy proceedings that continue for more
-                    than 60 days. In addition, either party may terminate an affected
-                    Order Form if a Force Majeure Event prevents the Product from
-                    materially operating for 30 or more consecutive days, and Provider
-                    will pay to Customer a prorated refund of prepaid fees for the
-                    remainder of the Subscription Period. A party must notify the
-                    other of its reason for termination.
-                  </li>
-                  <li>
-                    <span class="sub-clause-name">Effect of Termination.</span> Termination
-                    of the Agreement will automatically terminate all Order Forms.
-                    Upon expiration or termination:
-                    <ol>
-                      <li>
-                        Customer will no longer have any right to use the
-                        Product, Technical Support, or Professional Services.
-                      </li>
-                      <li>
-                        Upon Customer's request, Provider will delete Customer
-                        Content within 60 days.
-                      </li>
-                      <li>
-                        Each Recipient will return or destroy Discloser's
-                        Confidential Information in its possession or control.
-                      </li>
-                      <li>
-                        Provider will submit a final invoice for all outstanding
-                        fees accrued before termination and Customer will pay
-                        the invoice according to Section 5 (Payment & Taxes).
-                      </li>
-                    </ol>
-                  </li>
-                  <li>
-                    <span class="sub-clause-name">Survival.</span>
-                    <ol>
-                      <li>
-                        The following sections will survive expiration or
-                        termination of the Agreement: Section 1.6 (Feedback and
-                        Usage Data), Section 2.1 (Restrictions on Customer),
-                        Section 5 (Payment & Taxes) for fees accrued or payable
-                        before expiration or termination, Section 6.4 (Effect of
-                        Termination), Section 6.5 (Survival), Section 7
-                        (Representations & Warranties), Section 8 (Disclaimer of
-                        Warranties), Section 9 (Limitation of Liability),
-                        Section 10 (Indemnification), Section 11 (Insurance) for
-                        the time period specified, Section 12 (Confidentiality),
-                        Section 13 (Reservation of Rights), Section 14 (General
-                        Terms), Section 15 (Definitions), and the portions of a
-                        Cover Page referenced by these sections.
-                      </li>
-                      <li>
-                        Each Recipient may retain Discloser's Confidential
-                        Information in accordance with its standard backup or
-                        record retention policies maintained in the ordinary
-                        course of business or as required by Applicable Laws, in
-                        which case Section 4 (Privacy & Security) and Section 12
-                        (Confidentiality) will continue to apply to retained
-                        Confidential Information.
-                      </li>
-                    </ol>
-                  </li>
-                </ol>
-              </li>
-              <li>
-                <span class="clause-name">Representation & Warranties</span>
-                <ol>
-                  <li>
-                    <span class="sub-clause-name">Mutual.</span> Each party represents
-                    and warrants to the other that: (a) it has the legal power and
-                    authority to enter into this Agreement; (b) it is duly organized,
-                    validly existing, and in good standing under the Applicable Laws
-                    of the jurisdiction of its origin; (c) it will comply with all
-                    Applicable Laws in performing its obligations or exercising its
-                    rights in this Agreement; and (d) it will comply with the Additional
-                    Warranties.
-                  </li>
-                  <li>
-                    <span class="sub-clause-name">From Customer.</span> Customer
-                    represents and warrants that it, all Users, and anyone submitting
-                    Customer Content each have and will continue to have all rights
-                    necessary to submit or make available Customer Content to the
-                    Product and to allow the use of Customer Content as described
-                    in the Agreement.
-                  </li>
-                  <li>
-                    <span class="sub-clause-name">From Provider.</span> Provider
-                    represents and warrants to Customer that (a) it will not materially
-                    reduce the general functionality of the Cloud Service during
-                    a Subscription Period; and (b) it will perform Professional Services
-                    in a competent and professional manner.
-                  </li>
-                  <li>
-                    <span class="sub-clause-name"
-                      >Provider Warranty Remedy.</span
-                    > If Provider breaches a warranty in Section 7.3, Customer must
-                    give Provider notice (with enough detail for Provider to understand
-                    or replicate the issue) within 45 days of discovering the issue.
-                    Within 45 days of receiving sufficient details of the warranty
-                    issue, Provider will attempt to restore the general functionality
-                    of the Cloud Service or reperform the Professional Services.
-                    If Provider cannot resolve the issue, Customer may terminate
-                    the affected Order Form and Provider will pay to Customer a prorated
-                    refund of prepaid fees for the remainder of the Subscription
-                    Period. Provider's restoration and reperformance obligations,
-                    and Customer's termination right, are Customer's only remedies
-                    if Provider does not meet the warranties in Section 7.3.
-                  </li>
-                </ol>
-              </li>
-              <li>
-                <span class="clause-name">Disclaimer of Warranties</span>
+        </div>
+        <hr class="my-8" />
+        <!-- Cover Page -->
+        <div class="space-y-3">
+          <h2 class="font-bold text-2xl">Cover Page</h2>
+          <div class="space-y-6">
+            <!-- Order Form -->
+            <div>
+              <h3 class="font-bold text-lg mb-4">Order Form</h3>
+              <div class="pl-6 space-y-4">
                 <p>
-                  Provider makes no guarantees that the Product will always be
-                  safe, secure, or error-free, or that it will function without
-                  disruptions, delays, or imperfections. The warranties in
-                  Section 7.3 do not apply to any misuse or unauthorized
-                  modification of the Product, nor to any product or service
-                  provided by anyone other than Provider. Except for the
-                  warranties in Section 7, Provider and Customer each disclaim
-                  all other warranties, whether express or implied, including
-                  the implied warranties of merchantability, fitness for a
-                  particular purpose, title, and non-infringement. These
-                  disclaimers apply to the maximum extent permitted by
-                  Applicable Laws.
+                  <span class="font-semibold">Cloud Service:</span> Livebook Teams
+                  is a cloud-based software that allows you to deploy Livebook apps
+                  to your own server infrastructure.
                 </p>
-              </li>
-              <li>
-                <span class="clause-name">Limitation of Liability</span>
-                <ol>
-                  <li>
-                    <span class="sub-clause-name">Liability Caps</span>. If
-                    there are Increased Claims, each party's total cumulative
-                    liability for the Increased Claims arising out of or
-                    relating to this Agreement will not be more than the
-                    Increased Cap Amount. Each party's total cumulative
-                    liability for all other claims arising out of or relating to
-                    this Agreement will not be more than the General Cap Amount.
-                  </li>
-                  <li>
-                    <span class="sub-clause-name">Damages Waiver.</span> Each party's
-                    liability for any claim or liability arising out of or relating
-                    to this Agreement will be limited to the fullest extent permitted
-                    by Applicable Laws. Under no circumstances will either party
-                    be liable to the other for lost profits or revenues, or for consequential,
-                    special, indirect, exemplary, punitive, or incidental damages
-                    relating to this Agreement, even if the party is informed of
-                    the possibility of this type of damage in advance.
-                  </li>
-                  <li>
-                    <span class="sub-clause-name">Exceptions.</span> The liability
-                    caps in Section 9.1 and the damages waiver in Section 9.2 do
-                    not apply to any Unlimited Claims. The damages waiver in Section
-                    9.2 does not apply to any Increased Claims.
-                  </li>
-                </ol>
-              </li>
-              <li>
-                <span class="clause-name">Indemnification</span>
-                <ol>
-                  <li>
-                    <span class="sub-clause-name">Protection by Provider.</span>
-                    Provider will indemnify, defend, and hold harmless Customer from
-                    and against all Provider Covered Claims made by someone other
-                    than Customer, Customer's Affiliates, or Users, and all out-of-pocket
-                    damages, awards, settlements, costs, and expenses, including
-                    reasonable attorneys' fees and other legal expenses, that arise
-                    from the Provider Covered Claim.
-                  </li>
-                  <li>
-                    <span class="sub-clause-name">Protection by Customer.</span>
-                    Customer will indemnify, defend, and hold harmless Provider from
-                    and against all Customer Covered Claims made by someone other
-                    than Provider or its Affiliates, and all out-of-pocket damages,
-                    awards, settlements, costs, and expenses, including reasonable
-                    attorneys' fees and other legal expenses, that arise from the
-                    Customer Covered Claim.
-                  </li>
-                  <li>
-                    <span class="sub-clause-name">Procedure.</span> The Indemnifying
-                    Party's obligations in this section are contingent upon the Protected
-                    Party: (a) promptly notifying the Indemnifying Party of each
-                    Covered Claim for which it seeks protection; (b) providing reasonable
-                    assistance to the Indemnifying Party at the Indemnifying Party's
-                    expense; and (c) giving the Indemnifying Party sole control over
-                    the defense and settlement of each Covered Claim. A Protected
-                    Party may participate in a Covered Claim for which it seeks protection
-                    with its own attorneys only at its own expense. The Indemnifying
-                    Party may not agree to any settlement of a Covered Claim that
-                    contains an admission of fault or otherwise materially and adversely
-                    impacts the Protected Party without the prior written consent
-                    of the Protected Party.
-                  </li>
-                  <li>
-                    <span class="sub-clause-name">Changes to Product.</span> If required
-                    by settlement or court order, or if deemed reasonably necessary
-                    in response to a Provider Covered Claim, Provider may: (a) obtain
-                    the right for Customer to continue using the Product; (b) replace
-                    or modify the affected component of the Product without materially
-                    reducing the general functionality of the Product; or (c) if
-                    neither (a) nor (b) are reasonable, terminate the affected Order
-                    Form and issue a pro-rated refund of prepaid fees for the remainder
-                    of the Subscription Period.
-                  </li>
-                  <li>
-                    <span class="sub-clause-name">Exclusions.</span>
-                    <ol>
-                      <li>
-                        Provider's obligations as an Indemnifying Party will not
-                        apply to Provider Covered Claims that result from (i)
-                        modifications to the Product that were not authorized by
-                        Provider or that were made in compliance with Customer's
-                        instructions; (ii) unauthorized use of the Product,
-                        including use in violation of this Agreement; (iii) use
-                        of the Product in combination with items not provided by
-                        Provider; or (iv) use of an old version of the Product
-                        where a newer release would avoid the Provider Covered
-                        Claim.
-                      </li>
-                      <li>
-                        Customer's obligations as an Indemnifying Party will not
-                        apply to Customer Covered Claims that result from the
-                        unauthorized use of the Customer Content, including use
-                        in violation of this Agreement.
-                      </li>
-                    </ol>
-                  </li>
-                  <li>
-                    <span class="sub-clause-name">Exclusive Remedy.</span> This Section
-                    10 (Indemnification), together with any termination rights, describes
-                    each Protected Party's exclusive remedy and each Indemnifying
-                    Party's entire liability for a Covered Claim.
-                  </li>
-                </ol>
-                <li>
-                  <span class="clause-name">Insurance</span>
-                  <p>
-                    During the Subscription Period and for six months after,
-                    Provider will carry commercial insurance policies with
-                    coverage limits that meet the Insurance Minimums, if any.
-                    Upon request, Provider will give Customer a certificate of
-                    insurance evidencing its insurance policies that meet the
-                    Insurance Minimums. Provider's insurance policies will not
-                    be considered as evidence of Provider's liability.
-                  </p>
+                <p>
+                  <span class="font-semibold">Subscription Start Date:</span> The
+                  Effective Date.
+                </p>
+                <p>
+                  <span class="font-semibold">Subscription Period:</span> 1 month(s).
+                </p>
+                <p>
+                  <span class="font-semibold">Non-Renewal Notice Period:</span> At
+                  least 30 days before the end of the current Subscription Period.
+                </p>
+                <p>
+                  <span class="font-semibold">Cloud Service Fees:</span> Section
+                  5.2 of the Standard Terms is replaced with: Certain parts of the
+                  Product have different pricing plans, which are available at Provider's
+                  <a href="/teams/pricing" class="underline decoration-solid"
+                    >pricing page</a
+                  >. Within the Payment Period, Customer will pay Provider fees
+                  based on the Product tier selected at the time of account
+                  creation and Customer'is usage per Subscription Period.
+                  Provider may update Product pricing by giving at least 30 days
+                  notice to Customer (including by email or notification within
+                  the Product), and the change will apply in the next
+                  Subscription Period.
+                </p>
+                <p>
+                  <span class="font-semibold">Payment Period:</span> 7 day(s) from
+                  date of invoice.
+                </p>
+                <p>
+                  <span class="font-semibold">Invoice Period:</span> Monthly.
+                </p>
+              </div>
+            </div>
+            <!-- Key Terms -->
+            <div>
+              <h3 class="font-bold text-lg mb-4">Key Terms</h3>
+              <div class="pl-6 space-y-4">
+                <p>
+                  <span class="font-semibold">Customer:</span> The company or person
+                  who accesses or uses the Product. If the person accepting this
+                  Agreement is doing so on behalf of a company, all use of the word
+                  "Customer" in the Agreement will mean that company.
+                </p>
+                <p>
+                  <span class="font-semibold">Provider:</span> Elixir Services and
+                  Support.
+                </p>
+                <p>
+                  <span class="font-semibold">Effective Date:</span> The date Customer
+                  first accepts this Agreement.
+                </p>
+                <p>
+                  <span class="font-semibold">General Cap Amount:</span> The fees
+                  paid or payable by Customer to provider in the 12 month period
+                  immediately before the claim.
+                </p>
+                <p>
+                  <span class="font-semibold">Governing Law:</span> The laws of Poland.
+                </p>
+                <p>
+                  <span class="font-semibold">Chosen Courts:</span> Courts of Poland.
+                </p>
+                <p>
+                  <span class="font-semibold">Notice Address:</span>
+                  <ul class="list-disc list-inside space-y">
+                    <li>For Provider: notices@livebook.dev</li>
+                    <li>
+                      For Customer: The main address on Customer's account
+                    </li>
+                  </ul>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <hr class="my-8" />
+        <!-- Standard Terms -->
+        <div class="space-y-3">
+          <h2 class="font-bold text-2xl">
+            Standard Terms (Cloud Service Agreement)
+          </h2>
+          <ol
+            class="standard-terms space-y-6 list-inside [counter-reset:section] marker:font-semibold marker:text-lg"
+          >
+            <li
+              class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+            >
+              <span class="font-semibold text-lg">Service</span>
+              <ol
+                class="space-y-4 list-inside pl-6 my-4 [counter-reset:section] marker:font-normal marker:text-base"
+              >
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Access and Use.</span> During the Subscription
+                  Period and subject to the Use Limitations, Customer may (a) access
+                  and use the Cloud Service; and (b) copy and use the included Software
+                  and Documentation only as needed to access and use the Cloud Service,
+                  in each case, for its internal business purposes and only if Customer
+                  complies with the terms of this Agreement.
                 </li>
-                <li>
-                  <span class="clause-name">Confidentiality</span>
-                  <ol>
-                    <li>
-                      <span class="sub-clause-name"
-                        >Non-Use and Non-Disclosure.</span
-                      > Unless otherwise authorized in the Agreement, Recipient will
-                      (a) only use Discloser's Confidential Information to fulfill
-                      its obligations or exercise its rights under this Agreement;
-                      and (b) not disclose Discloser's Confidential Information to
-                      anyone else. In addition, Recipient will protect Discloser's
-                      Confidential Information using at least the same protections
-                      Recipient uses for its own similar information but no less
-                      than a reasonable standard of care.
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Service Level</span>. If there is an
+                  SLA and the Cloud Service does not meet the SLA, Provider will
+                  provide the remedies outlined in the SLA and will not be
+                  responsible for any other remedies. Any credits earned under
+                  the SLA will only apply to future invoices and expire if the
+                  Agreement ends. In any event, if the Cloud Service is
+                  temporarily unavailable for scheduled maintenance, for
+                  unscheduled emergency maintenance, or because of other causes
+                  beyond Provider's reasonable control, no SLA remedies will
+                  accrue. Provider will try to inform Customer before scheduled
+                  service disruptions through the Cloud Service or by email.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Support.</span> During the Subscription
+                  Period, Provider will provide Technical Support as described in
+                  the Cover Page, if any.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">User Accounts.</span> Customer is responsible
+                  for all actions on Users' accounts and for Users' compliance with
+                  this Agreement. Customer and Users must protect the confidentiality
+                  of their passwords and login credentials. Customer will promptly
+                  notify Provider if it suspects or knows of any fraudulent activity
+                  with its accounts, passwords, or credentials, or if they become
+                  compromised.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Affiliates.</span> If authorized in a Cover
+                  Page, individuals from Customer's Affiliates may access Customer's
+                  account as Users under Customer's Agreement and Customer will be
+                  responsible for its Affiliates' compliance with this Agreement.
+                  If a Customer Affiliate enters a separate Cover Page with Provider,
+                  the Customer's Affiliate creates a separate agreement between Provider
+                  and that Affiliate, where Provider's responsibility to the Affiliate
+                  is individual and separate from Customer and Customer is not responsible
+                  for its Affiliates' agreement.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Feedback and Usage Data.</span> Customer
+                  may, but is not required to, give Provider Feedback, in which case
+                  Customer gives Feedback "AS IS". Provider may use all Feedback
+                  freely without any restriction or obligation. In addition, Provider
+                  may collect and analyze Usage Data, and Provider may freely use
+                  Usage Data to maintain, improve, and enhance Provider's products
+                  and services without restriction or obligation. However, Provider
+                  may only share Usage Data with others if the Usage Data is aggregated
+                  and does not identify Customer or Users.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Customer Content.</span> Provider may copy,
+                  display, modify, and use Customer Content only as needed to provide
+                  and maintain the Product and related offerings. Customer is responsible
+                  for the accuracy and content of Customer Content.
+                </li>
+              </ol>
+            </li>
+            <li
+              class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+            >
+              <span class="font-semibold text-lg"
+                >Restrictions & Obligations</span
+              >
+              <ol
+                class="space-y-4 list-inside pl-6 my-4 [counter-reset:section] marker:font-normal marker:text-base"
+              >
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Restrictions on Customer.</span>
+                  <ol
+                    class="space-y-4 list-inside pl-6 my-4 [counter-reset:section]"
+                  >
+                    <li
+                      class="[counter-increment:section] marker:[content:counter(section,lower-alpha)_'._']"
+                    >
+                      Except as expressly permitted by this Agreement, Customer
+                      will not (and will not allow any anyone else to): (i)
+                      reverse engineer, decompile, or attempt to discover any
+                      source code or underlying ideas or algorithms of the
+                      Product (except to the extent Applicable Laws prohibit
+                      this restriction); (ii) provide, sell, transfer,
+                      sublicense, lend, distribute, rent, or otherwise allow
+                      others to access or use the Product; (iii) remove any
+                      proprietary notices or labels; (iv) copy, modify, or
+                      create derivative works of the Product; (v) conduct
+                      security or vulnerability tests on, interfere with the
+                      operation of, cause performance degradation of, or
+                      circumvent access restrictions of the Product; (vi) access
+                      accounts, information, data, or portions of the Product to
+                      which Customer does not have explicit authorization; (vii)
+                      use the Product to develop a competing service or product;
+                      (viii) use the Product with any High Risk Activities or
+                      with activity prohibited by Applicable Laws; (ix) use the
+                      Product to obtain unauthorized access to anyone else's
+                      networks or equipment; or (x) upload, submit, or otherwise
+                      make available to the Product any Customer Content to
+                      which Customer and Users do not have the proper rights.
                     </li>
-                    <li>
-                      <span class="sub-clause-name">Exclusions.</span> Confidential
-                      Information does not include information that (a) Recipient
-                      knew without any obligation of confidentiality before disclosure
-                      by Discloser; (b) is or becomes publicly known and generally
-                      available through no fault of Recipient; (c) Recipient receives
-                      under no obligation of confidentiality from someone else who
-                      is authorized to make the disclosure; or (d) Recipient independently
-                      developed without use of or reference to Discloser's Confidential
-                      Information.
-                    </li>
-                    <li>
-                      <span class="sub-clause-name">Required Disclosures.</span>
-                      Recipient may disclose Discloser's Confidential Information
-                      to the extent required by Applicable Laws if, unless prohibited
-                      by Applicable Laws, Recipient provides the Discloser reasonable
-                      advance notice of the required disclosure and reasonably cooperates,
-                      at the Discloser's expense, with the Discloser's efforts to
-                      obtain confidential treatment for the Confidential Information.
-                    </li>
-                    <li>
-                      <span class="sub-clause-name">Permitted Disclosures.</span
-                      > Recipient may disclose Discloser's Confidential Information
-                      to Users, employees, advisors, contractors, and representatives
-                      who each have a need to know the Confidential Information,
-                      but only if the person or entity is bound by confidentiality
-                      obligations at least as protective as those in this Section
-                      12 and Recipient remains responsible for everyone's compliance
-                      with the terms of this Section 12.
+                    <li
+                      class="[counter-increment:section] marker:[content:counter(section,lower-alpha)_'._']"
+                    >
+                      Customer's use of the Product must comply with all
+                      Documentation and the Acceptable Use Policy, if any.
                     </li>
                   </ol>
                 </li>
-                <li>
-                  <span class="clause-name">Reservation of Rights</span>
-                  <p>
-                    Except for the limited license to copy and use Software and
-                    Documentation in Section 1.1 (Access and Use), Provider
-                    retains all right, title, and interest in and to the
-                    Product, whether developed before or after the Effective
-                    Date. Except for the limited rights in Section 1.7 (Customer
-                    Content), Customer retains all right, title, and interest in
-                    and to the Customer Content.
-                  </p>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Suspension.</span> if Customer (a) has
+                  an outstanding, undisputed balance on its account for more than
+                  30 days after the Payment Period; (b) breaches Section 2.1 (Restrictions
+                  on Customer); or (c) uses the Product in violation of the Agreement
+                  or in a way that materially and negatively impacts the Product
+                  or others, then Provider may temporarily suspend Customer's access
+                  to the Product with or without notice. However, Provider will try
+                  to inform Customer before suspending Customer's account when practical.
+                  Provider will reinstate Customer's access to the Product only if
+                  Customer resolves the underlying issue.
                 </li>
-                <li>
-                  <span class="clause-name">General Terms</span>
-                  <ol>
-                    <li>
-                      <span class="sub-clause-name">Entire Agreement.</span> This
-                      Agreement is the only agreement between the parties about its
-                      subject and this Agreement supersedes all prior or contemporaneous
-                      statements (whether in writing or not) about its subject. Provider
-                      expressly rejects any terms included in Customer's purchase
-                      order or similar document, which may only be used for accounting
-                      or administrative purposes.
+              </ol>
+            </li>
+            <li
+              class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+            >
+              <span class="font-semibold text-lg">Professional Services</span><p
+                class="pl-6 my-4"
+              >
+                Provider will perform the Professional Services as detailed in a
+                Cover Page, if any, and Customer will reasonably cooperate with
+                Provider to allow the performance of Professional Services,
+                including providing Customer Content as needed. Provider is not
+                responsible for any inability to perform the Professional
+                Services if Customer does not cooperate as reasonably requested.
+              </p>
+            </li>
+            <li
+              class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+            >
+              <span class="font-semibold text-lg">Privacy & Security</span><ol
+                class="space-y-4 list-inside pl-6 my-4 [counter-reset:section] marker:font-normal marker:text-base"
+              >
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Personal Data.</span> Before submitting
+                  Personal Data governed by GDPR, Customer must enter into a data
+                  processing agreement with Provider. If the parties have a DPA,
+                  the terms of the DPA will control each party's rights and obligations
+                  as to Personal Data and the terms of the DPA will control in the
+                  event of any conflict with this Agreement.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Prohibited Data.</span> Customer will not
+                  (and will not allow anyone else to) submit Prohibited Data to the
+                  Product unless authorized by the Cover Page.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Security.</span> Provider will comply with
+                  the Security Policy, if any.
+                </li>
+              </ol>
+            </li>
+            <li
+              class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+            >
+              <span class="font-semibold text-lg">Payments & Taxes</span>
+              <ol
+                class="space-y-4 list-inside pl-6 my-4 [counter-reset:section] marker:font-normal marker:text-base"
+              >
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Fees and Invoices.</span> All fees are
+                  in U.S. Dollars and are exclusive of taxes. Except for the prorated
+                  refund of prepaid fees allowed with specific termination rights,
+                  fees are non-refundable. Provider will send invoices for fees applicable
+                  to the Product once per Invoice Period in advance starting on the
+                  Subscription Start Date. Invoices for Professional Services may
+                  be sent monthly during performance of the Professional Services
+                  unless the Cover Page includes a different cadence.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Payment.</span> Customer will pay Provider
+                  the fees and taxes in each invoice in U.S. Dollars within the Payment
+                  Period.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Taxes.</span> Customer is responsible for
+                  all duties, taxes, and levies that apply to fees, including sales,
+                  use, VAT, GST, or withholding, that Provider itemizes and includes
+                  in an invoice. However, Customer is not responsible for Provider's
+                  income taxes.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Payment Dispute.</span> If Customer has
+                  a good-faith disagreement about the amounts charged on an invoice,
+                  Customer must notify Provider about the dispute during the Payment
+                  Period for the invoice and must pay all undisputed amounts on time.
+                  The parties will work together to resolve the dispute within 15
+                  days after the end of the Payment Period. If no resolution is agreed,
+                  each party may pursue any remedies available under the Agreement
+                  or Applicable Laws.
+                </li>
+              </ol>
+            </li>
+            <li
+              class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+            >
+              <span class="font-semibold text-lg">Term & Termination</span>
+              <ol
+                class="space-y-4 list-inside pl-6 my-4 [counter-reset:section] marker:font-normal marker:text-base"
+              >
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Subscription Period.</span> Each Order
+                  Form will start on the Subscription Start Date, continue for the
+                  Subscription Period, and automatically renew for additional Subscription
+                  Periods unless one party gives notice of non-renewal to the other
+                  party before the Non-Renewal Notice Date.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Agreement Term.</span> This Agreement will
+                  start on the Effective Date and continue for the longer of one
+                  year or until all Subscription Periods have ended.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Termination.</span> Either party may terminate
+                  this Agreement if the other party (a) fails to cure a material
+                  breach of the Agreement within 30 days after receiving notice of
+                  the breach; (b) materially breaches the Agreement in a manner that
+                  cannot be cured; (c) dissolves or stops conducting business without
+                  a successor; (d) makes an assignment for the benefit of creditors;
+                  or (e) becomes the debtor in insolvency, receivership, or bankruptcy
+                  proceedings that continue for more than 60 days. In addition, either
+                  party may terminate an affected Order Form if a Force Majeure Event
+                  prevents the Product from materially operating for 30 or more consecutive
+                  days, and Provider will pay to Customer a prorated refund of prepaid
+                  fees for the remainder of the Subscription Period. A party must
+                  notify the other of its reason for termination.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Effect of Termination.</span> Termination
+                  of the Agreement will automatically terminate all Order Forms.
+                  Upon expiration or termination:
+                  <ol
+                    class="space-y-4 list-inside pl-6 my-4 [counter-reset:section]"
+                  >
+                    <li
+                      class="[counter-increment:section] marker:[content:counter(section,lower-alpha)_'._']"
+                    >
+                      Customer will no longer have any right to use the Product,
+                      Technical Support, or Professional Services.
                     </li>
-                    <li>
-                      <span class="sub-clause-name"
-                        >Modifications, Severability, and Waiver.</span
-                      > Any waiver, modification, or change to the Agreement must
-                      be in writing and signed or electronically accepted by each
-                      party. However, Provider may update Technical Support, the
-                      SLA, the Security Policy, or the Acceptable Use Policy by giving
-                      Customer 30 days prior notice. During the 30-day notice period,
-                      Customer may terminate the Agreement or affected Order Form
-                      upon notice if the update is a material reduction from the
-                      prior version and Provider cannot reasonably restore the prior
-                      version or a comparable alternative. If any term of this Agreement
-                      is determined to be invalid or unenforceable by a relevant
-                      court or governing body, the remaining terms of this Agreement
-                      will remain in full force and effect. The failure of a party
-                      to enforce a term or to exercise an option or right in this
-                      Agreement will not constitute a waiver by that party of the
-                      term, option, or right.
+                    <li
+                      class="[counter-increment:section] marker:[content:counter(section,lower-alpha)_'._']"
+                    >
+                      Upon Customer's request, Provider will delete Customer
+                      Content within 60 days.
                     </li>
-                    <li>
-                      <span class="sub-clause-name"
-                        >Governing Law and Chosen Courts.</span
-                      > The Governing Law will govern all interpretations and disputes
-                      about this Agreement, without regard to its conflict of laws
-                      provisions. The parties will bring any legal suit, action,
-                      or proceeding about this Agreement in the Chosen Courts and
-                      each party irrevocably submits to the exclusive jurisdiction
-                      of the Chosen Courts.
+                    <li
+                      class="[counter-increment:section] marker:[content:counter(section,lower-alpha)_'._']"
+                    >
+                      Each Recipient will return or destroy Discloser's
+                      Confidential Information in its possession or control.
                     </li>
-                    <li>
-                      <span class="sub-clause-name">Injunctive Relief.</span> Despite
-                      Section 14.3 (Governing Law and Chosen Courts), a breach of
-                      Section 12 (Confidentiality) or the violation of a party's
-                      intellectual property rights may cause irreparable harm for
-                      which monetary damages cannot adequately compensate. As a result,
-                      upon the actual or threatened breach of Section 12 (Confidentiality)
-                      or violation of a party's intellectual property rights, the
-                      non-breaching or non-violating party may seek appropriate equitable
-                      relief, including an injunction, in any court of competent
-                      jurisdiction without the need to post a bond and without limiting
-                      its other rights or remedies.
-                    </li>
-                    <li>
-                      <span class="sub-clause-name"
-                        >Non-Exhaustive Remedies.</span
-                      > Except where the Agreement provides for an exclusive remedy,
-                      seeking or exercising a remedy does not limit the other rights
-                      or remedies available to a party.
-                    </li>
-                    <li>
-                      <span class="sub-clause-name"> Assignment.</span> Neither party
-                      may assign any rights or obligations under this Agreement without
-                      the prior written consent of the other party. However, either
-                      party may assign this Agreement upon notice if the assigning
-                      party undergoes a merger, change of control, reorganization,
-                      or sale of all or substantially all its equity, business, or
-                      assets to which this Agreement relates. Any attempted but non-permitted
-                      assignment is void. This Agreement will be binding upon and
-                      inure to the benefit of the parties and their permitted successors
-                      and assigns.
-                    </li>
-                    <li>
-                      <span class="sub-clause-name">No Publicity.</span> Neither
-                      party may publicly announce the existence of this Agreement
-                      without the prior written approval of the other party.
-                    </li>
-                    <li>
-                      <span class="sub-clause-name">Notices.</span> Any notice, request,
-                      or approval about the Agreement must be in writing and sent
-                      to the Notice Address. Notices will be deemed given (a) upon
-                      confirmed delivery if by email, registered or certified mail,
-                      or personal delivery; or (b) two days after mailing if by overnight
-                      commercial delivery.
-                    </li>
-                    <li>
-                      <span class="sub-clause-name"
-                        >Independent Contractors.</span
-                      > The parties are independent contractors, not agents, partners,
-                      or joint venturers. Neither party is authorized to bind the
-                      other to any liability or obligation.
-                    </li>
-                    <li>
-                      <span class="sub-clause-name"
-                        >No Third-Party Beneficiary.</span
-                      > There are no third-party beneficiaries of this Agreement.
-                    </li>
-                    <li>
-                      <span class="sub-clause-name">Force Majeure.</span> Neither
-                      party will be liable for a delay or failure to perform its
-                      obligations of this Agreement if caused by a Force Majeure
-                      Event. However, this section does not excuse Customer's obligations
-                      to pay fees.
-                    </li>
-                    <li>
-                      <span class="sub-clause-name">Export Controls.</span> Customer
-                      may not remove or export from the United States or allow the
-                      export or re-export of the Product or any related technology
-                      or materials in violation of any restrictions, laws, or regulations
-                      of the United States Department of Commerce, the United States
-                      Department of Treasury Office of Foreign Assets Control, or
-                      any other United States or foreign agency or authority.
-                    </li>
-                    <li>
-                      <span class="sub-clause-name">Government Rights.</span> The
-                      Cloud Service and Software are deemed "commercial items" or
-                      "commercial computer software" according to FAR section 12.212
-                      and DFAR section 227.7202, and the Documentation is "commercial
-                      computer software documentation" according to DFAR section
-                      252.227-7014(a)(1) and (5). Any use, modification, reproduction,
-                      release, performance, display, or disclosure of the Product
-                      by the U.S. Government will be governed solely by the terms
-                      of this Agreement and all other use is prohibited.
-                    </li>
-                    <li>
-                      <span class="sub-clause-name">Anti-Bribery.</span> Neither
-                      party will take any action that would be a violation of any
-                      Applicable Laws that prohibit the offering, giving, promising
-                      to offer or give, or receiving, directly or indirectly, money
-                      or anything of value to any third party to assist Provider
-                      or Customer in retaining or obtaining business. Examples of
-                      these kinds of laws include the U.S. Foreign Corrupt Practices
-                      Act and the UK Bribery Act 2010.
-                    </li>
-                    <li>
-                      <span class="sub-clause-name"
-                        >Titles and Interpretation.</span
-                      > Section titles are for convenience and reference only. All
-                      uses of "including" and similar phrases are non-exhaustive
-                      and without limitation. The United Nations Convention for the
-                      International Sale of Goods and the Uniform Computer Information
-                      Transaction Act do not apply to this Agreement.
-                    </li>
-                    <li>
-                      <span class="sub-clause-name">Signature.</span> This Agreement
-                      may be signed in counterparts, including by electronic copies
-                      or acceptance mechanism. Each copy will be deemed an original
-                      and all copies, when taken together, will be the same agreement.
+                    <li
+                      class="[counter-increment:section] marker:[content:counter(section,lower-alpha)_'._']"
+                    >
+                      Provider will submit a final invoice for all outstanding
+                      fees accrued before termination and Customer will pay the
+                      invoice according to Section 5 (Payment & Taxes).
                     </li>
                   </ol>
                 </li>
-                <li>
-                  <span class="clause-name">Definitions</span>
-                  <ol>
-                    <li>
-                      <span class="font-semibold">"Affiliate"</span> means an entity
-                      that, directly or indirectly, controls, is under the control
-                      of, or is under common control with a party, where control
-                      means having more than fifty percent (50%) of the voting stock
-                      or other ownership interest.
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Survival.</span>
+                  <ol
+                    class="space-y-4 list-inside pl-6 my-4 [counter-reset:section]"
+                  >
+                    <li
+                      class="[counter-increment:section] marker:[content:counter(section,lower-alpha)_'._']"
+                    >
+                      The following sections will survive expiration or
+                      termination of the Agreement: Section 1.6 (Feedback and
+                      Usage Data), Section 2.1 (Restrictions on Customer),
+                      Section 5 (Payment & Taxes) for fees accrued or payable
+                      before expiration or termination, Section 6.4 (Effect of
+                      Termination), Section 6.5 (Survival), Section 7
+                      (Representations & Warranties), Section 8 (Disclaimer of
+                      Warranties), Section 9 (Limitation of Liability), Section
+                      10 (Indemnification), Section 11 (Insurance) for the time
+                      period specified, Section 12 (Confidentiality), Section 13
+                      (Reservation of Rights), Section 14 (General Terms),
+                      Section 15 (Definitions), and the portions of a Cover Page
+                      referenced by these sections.
                     </li>
-                    <li>
-                      <span class="font-semibold">"Agreement"</span> means these
-                      Standard Terms, together with the Cover Pages between Provider
-                      and Customer that include or reference a single set of Key
-                      Terms and the policies and documents referenced in or attached
-                      to those Cover Pages.
+                    <li
+                      class="[counter-increment:section] marker:[content:counter(section,lower-alpha)_'._']"
+                    >
+                      Each Recipient may retain Discloser's Confidential
+                      Information in accordance with its standard backup or
+                      record retention policies maintained in the ordinary
+                      course of business or as required by Applicable Laws, in
+                      which case Section 4 (Privacy & Security) and Section 12
+                      (Confidentiality) will continue to apply to retained
+                      Confidential Information.
                     </li>
-                    <li>
-                      <span class="font-semibold">"Applicable Data Protection Laws"</span> means the Applicable
-                      Laws that govern how the Cloud Service may process or use
-                      an individual's personal information, personal data,
-                      personally identifiable information, or other similar
-                      term.
-                    </li>
-                    <li>
-                      <span class="font-semibold">"Applicable Laws"</span> means the laws, rules, regulations,
-                      court orders, and other binding requirements of a relevant
-                      government authority that apply to or govern Provider or
-                      Customer.
-                    </li>
-                    <li>
-                      <span class="font-semibold">"Cloud Service"</span> means the product described in an Order
-                      Form.
-                    </li>
-                    <li>
-                      <span class="font-semibold">"Confidential Information"</span> means information in any form
-                      disclosed by or on behalf of a Discloser, including before
-                      the Effective Date, to a Recipient in connection with this
-                      Agreement that (a) the Discloser identifies as
-                      "confidential", "proprietary", or the like; or (b) should
-                      be reasonably understood as confidential or proprietary
-                      due to its nature and the circumstances of its disclosure.
-                      Confidential Information includes the existence of this
-                      Agreement and the information on each Cover Page.
-                      Customer's Confidential Information includes non-public
-                      Customer Content and Provider's Confidential Information
-                      includes non-public information about the Product.
-                    </li>
-                    <li>
-                      <span class="font-semibold">"Cover Page"</span> means a document that is signed or
-                      electronically accepted by the parties that incorporates
-                      these Standard Terms, identifies Provider and Customer,
-                      and may include an Order Form, Key Terms, or both.
-                    </li>
-                    <li>
-                      <span class="font-semibold">"Covered Claim"</span> means either a Provider Covered Claim or
-                      Customer Covered Claim.
-                    </li>
-                    <li>
-                      <span class="font-semibold">"Customer Content"</span> means data, information, or materials
-                      submitted by or on behalf of Customer or Users to the
-                      Product, but excludes Feedback.
-                    </li>
-                    <li>
-                      <span class="font-semibold">"Discloser"</span> means a party to this Agreement when the party
-                      is providing or disclosing Confidential Information to the
-                      other party.
-                    </li>
-                    <li>
-                      <span class="font-semibold">"Documentation"</span> means the usage manuals and instructional
-                      materials for the Cloud Service or Software that are made
-                      available by Provider.
-                    </li>
-                    <li>
-                      <span class="font-semibold">"Feedback"</span> means suggestions, feedback, or comments about
-                      the Product or related offerings.
-                    </li>
-                    <li>
-                      <span class="font-semibold">"Force Majeure Event"</span> means an unforeseen event outside a
-                      party's reasonable control where the affected party took
-                      reasonable measures to avoid or mitigate the impacts of
-                      the event. Examples of these kinds of events include
-                      unpredicted natural disaster like a major earthquake, war,
-                      pandemic, riot, act of terrorism, or public utility or
-                      internet failure.
-                    </li>
-                    <li>
-                      <span class="font-semibold">"GDPR"</span> means European Union Regulation 2016/679 as
-                      implemented by local law in the relevant European Union
-                      member nation, and by section 3 of the United Kingdom's
-                      European Union (Withdrawal) Act of 2018 in the United
-                      Kingdom.
-                    </li>
-                    <li>
-                      <span class="font-semibold">"High Risk Activity"</span> means any situation where the use or
-                      failure of the Product could be reasonably expected to
-                      lead to death, bodily injury, or environmental damage.
-                      Examples include full or partial autonomous vehicle
-                      technology, medical life-support technology, emergency
-                      response services, nuclear facilities operation, and air
-                      traffic control.
-                    </li>
-                    <li>
-                      <span class="font-semibold">"Indemnifying Party"</span> means a party to this Agreement when
-                      the party is providing protection for a particular Covered
+                  </ol>
+                </li>
+              </ol>
+            </li>
+            <li
+              class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+            >
+              <span class="font-semibold text-lg"
+                >Representation & Warranties</span
+              >
+              <ol
+                class="space-y-4 list-inside pl-6 my-4 [counter-reset:section] marker:font-normal marker:text-base"
+              >
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Mutual.</span> Each party represents and
+                  warrants to the other that: (a) it has the legal power and authority
+                  to enter into this Agreement; (b) it is duly organized, validly
+                  existing, and in good standing under the Applicable Laws of the
+                  jurisdiction of its origin; (c) it will comply with all Applicable
+                  Laws in performing its obligations or exercising its rights in
+                  this Agreement; and (d) it will comply with the Additional Warranties.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">From Customer.</span> Customer represents
+                  and warrants that it, all Users, and anyone submitting Customer
+                  Content each have and will continue to have all rights necessary
+                  to submit or make available Customer Content to the Product and
+                  to allow the use of Customer Content as described in the Agreement.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">From Provider.</span> Provider represents
+                  and warrants to Customer that (a) it will not materially reduce
+                  the general functionality of the Cloud Service during a Subscription
+                  Period; and (b) it will perform Professional Services in a competent
+                  and professional manner.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Provider Warranty Remedy.</span> If Provider
+                  breaches a warranty in Section 7.3, Customer must give Provider
+                  notice (with enough detail for Provider to understand or replicate
+                  the issue) within 45 days of discovering the issue. Within 45 days
+                  of receiving sufficient details of the warranty issue, Provider
+                  will attempt to restore the general functionality of the Cloud
+                  Service or reperform the Professional Services. If Provider cannot
+                  resolve the issue, Customer may terminate the affected Order Form
+                  and Provider will pay to Customer a prorated refund of prepaid
+                  fees for the remainder of the Subscription Period. Provider's restoration
+                  and reperformance obligations, and Customer's termination right,
+                  are Customer's only remedies if Provider does not meet the warranties
+                  in Section 7.3.
+                </li>
+              </ol>
+            </li>
+            <li
+              class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+            >
+              <span class="font-semibold text-lg">Disclaimer of Warranties</span
+              >
+              <p class="pl-6 my-4">
+                Provider makes no guarantees that the Product will always be
+                safe, secure, or error-free, or that it will function without
+                disruptions, delays, or imperfections. The warranties in Section
+                7.3 do not apply to any misuse or unauthorized modification of
+                the Product, nor to any product or service provided by anyone
+                other than Provider. Except for the warranties in Section 7,
+                Provider and Customer each disclaim all other warranties,
+                whether express or implied, including the implied warranties of
+                merchantability, fitness for a particular purpose, title, and
+                non-infringement. These disclaimers apply to the maximum extent
+                permitted by Applicable Laws.
+              </p>
+            </li>
+            <li
+              class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+            >
+              <span class="font-semibold text-lg">Limitation of Liability</span>
+              <ol
+                class="space-y-4 list-inside pl-6 my-4 [counter-reset:section] marker:font-normal marker:text-base"
+              >
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Liability Caps</span>. If there are
+                  Increased Claims, each party's total cumulative liability for
+                  the Increased Claims arising out of or relating to this
+                  Agreement will not be more than the Increased Cap Amount. Each
+                  party's total cumulative liability for all other claims
+                  arising out of or relating to this Agreement will not be more
+                  than the General Cap Amount.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Damages Waiver.</span> Each party's liability
+                  for any claim or liability arising out of or relating to this Agreement
+                  will be limited to the fullest extent permitted by Applicable Laws.
+                  Under no circumstances will either party be liable to the other
+                  for lost profits or revenues, or for consequential, special, indirect,
+                  exemplary, punitive, or incidental damages relating to this Agreement,
+                  even if the party is informed of the possibility of this type of
+                  damage in advance.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Exceptions.</span> The liability caps in
+                  Section 9.1 and the damages waiver in Section 9.2 do not apply
+                  to any Unlimited Claims. The damages waiver in Section 9.2 does
+                  not apply to any Increased Claims.
+                </li>
+              </ol>
+            </li>
+            <li
+              class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+            >
+              <span class="font-semibold text-lg">Indemnification</span>
+              <ol
+                class="space-y-4 list-inside pl-6 my-4 [counter-reset:section] marker:font-normal marker:text-base"
+              >
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Protection by Provider.</span>
+                  Provider will indemnify, defend, and hold harmless Customer from
+                  and against all Provider Covered Claims made by someone other than
+                  Customer, Customer's Affiliates, or Users, and all out-of-pocket
+                  damages, awards, settlements, costs, and expenses, including reasonable
+                  attorneys' fees and other legal expenses, that arise from the Provider
+                  Covered Claim.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Protection by Customer.</span>
+                  Customer will indemnify, defend, and hold harmless Provider from
+                  and against all Customer Covered Claims made by someone other than
+                  Provider or its Affiliates, and all out-of-pocket damages, awards,
+                  settlements, costs, and expenses, including reasonable attorneys'
+                  fees and other legal expenses, that arise from the Customer Covered
+                  Claim.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Procedure.</span> The Indemnifying Party's
+                  obligations in this section are contingent upon the Protected Party:
+                  (a) promptly notifying the Indemnifying Party of each Covered Claim
+                  for which it seeks protection; (b) providing reasonable assistance
+                  to the Indemnifying Party at the Indemnifying Party's expense;
+                  and (c) giving the Indemnifying Party sole control over the defense
+                  and settlement of each Covered Claim. A Protected Party may participate
+                  in a Covered Claim for which it seeks protection with its own attorneys
+                  only at its own expense. The Indemnifying Party may not agree to
+                  any settlement of a Covered Claim that contains an admission of
+                  fault or otherwise materially and adversely impacts the Protected
+                  Party without the prior written consent of the Protected Party.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Changes to Product.</span> If required
+                  by settlement or court order, or if deemed reasonably necessary
+                  in response to a Provider Covered Claim, Provider may: (a) obtain
+                  the right for Customer to continue using the Product; (b) replace
+                  or modify the affected component of the Product without materially
+                  reducing the general functionality of the Product; or (c) if neither
+                  (a) nor (b) are reasonable, terminate the affected Order Form and
+                  issue a pro-rated refund of prepaid fees for the remainder of the
+                  Subscription Period.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Exclusions.</span>
+                  <ol
+                    class="space-y-4 list-inside pl-6 my-4 [counter-reset:section]"
+                  >
+                    <li
+                      class="[counter-increment:section] marker:[content:counter(section,lower-alpha)_'._']"
+                    >
+                      Provider's obligations as an Indemnifying Party will not
+                      apply to Provider Covered Claims that result from (i)
+                      modifications to the Product that were not authorized by
+                      Provider or that were made in compliance with Customer's
+                      instructions; (ii) unauthorized use of the Product,
+                      including use in violation of this Agreement; (iii) use of
+                      the Product in combination with items not provided by
+                      Provider; or (iv) use of an old version of the Product
+                      where a newer release would avoid the Provider Covered
                       Claim.
                     </li>
-                    <li>
-                      <span class="font-semibold">"Key Terms"</span> means the portion of a Cover Page that
-                      includes the key legal details and definitions for this
-                      Agreement that are not defined in the Standard Terms. The
-                      Key Terms may include details about Covered Claims, set
-                      the Governing Law, or contain other details about this
-                      Agreement.
-                    </li>
-                    <li>
-                      <span class="font-semibold">"Order Form"</span> means the portion of a Cover Page that
-                      includes the key business details and definitions for this
-                      Agreement that are not defined in the Standard Terms. An
-                      Order Form may include details about the level of access
-                      and use granted to the Cloud Service, nature and timing of
-                      Professional Services, extent of Technical Support, or
-                      other details about the Product.
-                    </li>
-                    <li>
-                      <span class="font-semibold">"Personal Data"</span> will have the meaning(s) set forth in the
-                      Applicable Data Protection Laws for personal information,
-                      personal data, personally identifiable information, or
-                      other similar term.
-                    </li>
-                    <li>
-                      <span class="font-semibold">"Product"</span> means the Cloud Service, Software, and
-                      Documentation.
-                    </li>
-                    <li>
-                      <span class="font-semibold">"Prohibited Data"</span> means (a) patient, medical, or other
-                      protected health information regulated by the Health
-                      Insurance Portability and Accountability Act; (b) credit,
-                      debit, bank account, or other financial account numbers;
-                      (c) social security numbers, driver's license numbers, or
-                      other unique and private government ID numbers; (d)
-                      special categories of data as defined in the GDPR; and (e)
-                      other similar categories of sensitive information as set
-                      forth in the Applicable Data Protection Laws.
-                    </li>
-                    <li>
-                      <span class="font-semibold">"Protected Party"</span> means a party to this Agreement when the
-                      party is receiving the benefit of protection for a
-                      particular Covered Claim.
-                    </li>
-                    <li>
-                      <span class="font-semibold">"Recipient"</span> means a party to this Agreement when the party
-                      receives Confidential Information from the other party.
-                    </li>
-                    <li>
-                      <span class="font-semibold">"Software"</span> means the client-side software or applications
-                      made available by Provider for Customer to install,
-                      download (whether onto a machine or in a browser), or
-                      execute as part of the Product.
-                    </li>
-                    <li>
-                      <span class="font-semibold">"Usage Data"</span> means data and information about the
-                      provision, use, and performance of the Product and related
-                      offerings based on Customer's or User's use of the
-                      Product.
-                    </li>
-                    <li>
-                      <span class="font-semibold">"User"</span> means any individual who uses the Product on
-                      Customer's behalf or through Customer's account.
+                    <li
+                      class="[counter-increment:section] marker:[content:counter(section,lower-alpha)_'._']"
+                    >
+                      Customer's obligations as an Indemnifying Party will not
+                      apply to Customer Covered Claims that result from the
+                      unauthorized use of the Customer Content, including use in
+                      violation of this Agreement.
                     </li>
                   </ol>
                 </li>
-              </li>
-            </ol>
-          </div>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Exclusive Remedy.</span> This Section 10
+                  (Indemnification), together with any termination rights, describes
+                  each Protected Party's exclusive remedy and each Indemnifying Party's
+                  entire liability for a Covered Claim.
+                </li>
+              </ol>
+            </li>
+            <li
+              class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+            >
+              <span class="font-semibold text-lg">Insurance</span>
+              <p class="pl-6 my-4">
+                During the Subscription Period and for six months after,
+                Provider will carry commercial insurance policies with coverage
+                limits that meet the Insurance Minimums, if any. Upon request,
+                Provider will give Customer a certificate of insurance
+                evidencing its insurance policies that meet the Insurance
+                Minimums. Provider's insurance policies will not be considered
+                as evidence of Provider's liability.
+              </p>
+            </li>
+            <li
+              class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+            >
+              <span class="font-semibold text-lg">Confidentiality</span>
+              <ol
+                class="space-y-4 list-inside pl-6 my-4 [counter-reset:section] marker:font-normal marker:text-base"
+              >
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Non-Use and Non-Disclosure.</span>
+                  Unless otherwise authorized in the Agreement, Recipient will (a)
+                  only use Discloser's Confidential Information to fulfill its obligations
+                  or exercise its rights under this Agreement; and (b) not disclose
+                  Discloser's Confidential Information to anyone else. In addition,
+                  Recipient will protect Discloser's Confidential Information using
+                  at least the same protections Recipient uses for its own similar
+                  information but no less than a reasonable standard of care.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Exclusions.</span> Confidential Information
+                  does not include information that (a) Recipient knew without any
+                  obligation of confidentiality before disclosure by Discloser; (b)
+                  is or becomes publicly known and generally available through no
+                  fault of Recipient; (c) Recipient receives under no obligation
+                  of confidentiality from someone else who is authorized to make
+                  the disclosure; or (d) Recipient independently developed without
+                  use of or reference to Discloser's Confidential Information.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Required Disclosures.</span>
+                  Recipient may disclose Discloser's Confidential Information to
+                  the extent required by Applicable Laws if, unless prohibited by
+                  Applicable Laws, Recipient provides the Discloser reasonable advance
+                  notice of the required disclosure and reasonably cooperates, at
+                  the Discloser's expense, with the Discloser's efforts to obtain
+                  confidential treatment for the Confidential Information.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Permitted Disclosures.</span> Recipient
+                  may disclose Discloser's Confidential Information to Users, employees,
+                  advisors, contractors, and representatives who each have a need
+                  to know the Confidential Information, but only if the person or
+                  entity is bound by confidentiality obligations at least as protective
+                  as those in this Section 12 and Recipient remains responsible for
+                  everyone's compliance with the terms of this Section 12.
+                </li>
+              </ol>
+            </li>
+            <li
+              class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+            >
+              <span class="font-semibold text-lg">Reservation of Rights</span>
+              <p class="pl-6 my-4">
+                Except for the limited license to copy and use Software and
+                Documentation in Section 1.1 (Access and Use), Provider retains
+                all right, title, and interest in and to the Product, whether
+                developed before or after the Effective Date. Except for the
+                limited rights in Section 1.7 (Customer Content), Customer
+                retains all right, title, and interest in and to the Customer
+                Content.
+              </p>
+            </li>
+            <li
+              class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+            >
+              <span class="font-semibold text-lg">General Terms</span>
+              <ol
+                class="space-y-4 list-inside pl-6 my-4 [counter-reset:section] marker:font-normal marker:text-base"
+              >
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Entire Agreement.</span> This Agreement
+                  is the only agreement between the parties about its subject and
+                  this Agreement supersedes all prior or contemporaneous statements
+                  (whether in writing or not) about its subject. Provider expressly
+                  rejects any terms included in Customer's purchase order or similar
+                  document, which may only be used for accounting or administrative
+                  purposes.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline"
+                    >Modifications, Severability, and Waiver.</span
+                  > Any waiver, modification, or change to the Agreement must be
+                  in writing and signed or electronically accepted by each party.
+                  However, Provider may update Technical Support, the SLA, the Security
+                  Policy, or the Acceptable Use Policy by giving Customer 30 days
+                  prior notice. During the 30-day notice period, Customer may terminate
+                  the Agreement or affected Order Form upon notice if the update
+                  is a material reduction from the prior version and Provider cannot
+                  reasonably restore the prior version or a comparable alternative.
+                  If any term of this Agreement is determined to be invalid or unenforceable
+                  by a relevant court or governing body, the remaining terms of this
+                  Agreement will remain in full force and effect. The failure of
+                  a party to enforce a term or to exercise an option or right in
+                  this Agreement will not constitute a waiver by that party of the
+                  term, option, or right.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Governing Law and Chosen Courts.</span
+                  > The Governing Law will govern all interpretations and disputes
+                  about this Agreement, without regard to its conflict of laws provisions.
+                  The parties will bring any legal suit, action, or proceeding about
+                  this Agreement in the Chosen Courts and each party irrevocably
+                  submits to the exclusive jurisdiction of the Chosen Courts.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Injunctive Relief.</span> Despite Section
+                  14.3 (Governing Law and Chosen Courts), a breach of Section 12
+                  (Confidentiality) or the violation of a party's intellectual property
+                  rights may cause irreparable harm for which monetary damages cannot
+                  adequately compensate. As a result, upon the actual or threatened
+                  breach of Section 12 (Confidentiality) or violation of a party's
+                  intellectual property rights, the non-breaching or non-violating
+                  party may seek appropriate equitable relief, including an injunction,
+                  in any court of competent jurisdiction without the need to post
+                  a bond and without limiting its other rights or remedies.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Non-Exhaustive Remedies.</span> Except
+                  where the Agreement provides for an exclusive remedy, seeking or
+                  exercising a remedy does not limit the other rights or remedies
+                  available to a party.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline"> Assignment.</span> Neither party may assign
+                  any rights or obligations under this Agreement without the prior
+                  written consent of the other party. However, either party may assign
+                  this Agreement upon notice if the assigning party undergoes a merger,
+                  change of control, reorganization, or sale of all or substantially
+                  all its equity, business, or assets to which this Agreement relates.
+                  Any attempted but non-permitted assignment is void. This Agreement
+                  will be binding upon and inure to the benefit of the parties and
+                  their permitted successors and assigns.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">No Publicity.</span> Neither party may
+                  publicly announce the existence of this Agreement without the prior
+                  written approval of the other party.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Notices.</span> Any notice, request, or
+                  approval about the Agreement must be in writing and sent to the
+                  Notice Address. Notices will be deemed given (a) upon confirmed
+                  delivery if by email, registered or certified mail, or personal
+                  delivery; or (b) two days after mailing if by overnight commercial
+                  delivery.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Independent Contractors.</span> The parties
+                  are independent contractors, not agents, partners, or joint venturers.
+                  Neither party is authorized to bind the other to any liability
+                  or obligation.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">No Third-Party Beneficiary.</span>
+                  There are no third-party beneficiaries of this Agreement.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Force Majeure.</span> Neither party will
+                  be liable for a delay or failure to perform its obligations of
+                  this Agreement if caused by a Force Majeure Event. However, this
+                  section does not excuse Customer's obligations to pay fees.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Export Controls.</span> Customer may not
+                  remove or export from the United States or allow the export or
+                  re-export of the Product or any related technology or materials
+                  in violation of any restrictions, laws, or regulations of the United
+                  States Department of Commerce, the United States Department of
+                  Treasury Office of Foreign Assets Control, or any other United
+                  States or foreign agency or authority.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Government Rights.</span> The Cloud Service
+                  and Software are deemed "commercial items" or "commercial computer
+                  software" according to FAR section 12.212 and DFAR section 227.7202,
+                  and the Documentation is "commercial computer software documentation"
+                  according to DFAR section 252.227-7014(a)(1) and (5). Any use,
+                  modification, reproduction, release, performance, display, or disclosure
+                  of the Product by the U.S. Government will be governed solely by
+                  the terms of this Agreement and all other use is prohibited.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Anti-Bribery.</span> Neither party will
+                  take any action that would be a violation of any Applicable Laws
+                  that prohibit the offering, giving, promising to offer or give,
+                  or receiving, directly or indirectly, money or anything of value
+                  to any third party to assist Provider or Customer in retaining
+                  or obtaining business. Examples of these kinds of laws include
+                  the U.S. Foreign Corrupt Practices Act and the UK Bribery Act 2010.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Titles and Interpretation.</span> Section
+                  titles are for convenience and reference only. All uses of "including"
+                  and similar phrases are non-exhaustive and without limitation.
+                  The United Nations Convention for the International Sale of Goods
+                  and the Uniform Computer Information Transaction Act do not apply
+                  to this Agreement.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="underline">Signature.</span> This Agreement may be
+                  signed in counterparts, including by electronic copies or acceptance
+                  mechanism. Each copy will be deemed an original and all copies,
+                  when taken together, will be the same agreement.
+                </li>
+              </ol>
+            </li>
+            <li
+              class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+            >
+              <span class="font-semibold text-lg">Definitions</span>
+              <ol
+                class="space-y-4 list-inside pl-6 my-4 [counter-reset:section] marker:font-normal marker:text-base"
+              >
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="font-semibold">"Affiliate"</span> means an entity
+                  that, directly or indirectly, controls, is under the control of,
+                  or is under common control with a party, where control means having
+                  more than fifty percent (50%) of the voting stock or other ownership
+                  interest.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="font-semibold">"Agreement"</span> means these Standard
+                  Terms, together with the Cover Pages between Provider and Customer
+                  that include or reference a single set of Key Terms and the policies
+                  and documents referenced in or attached to those Cover Pages.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="font-semibold"
+                    >"Applicable Data Protection Laws"</span
+                  > means the Applicable Laws that govern how the Cloud Service may
+                  process or use an individual's personal information, personal data,
+                  personally identifiable information, or other similar term.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="font-semibold">"Applicable Laws"</span> means the
+                  laws, rules, regulations, court orders, and other binding requirements
+                  of a relevant government authority that apply to or govern Provider
+                  or Customer.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="font-semibold">"Cloud Service"</span> means the product
+                  described in an Order Form.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="font-semibold">"Confidential Information"</span> means
+                  information in any form disclosed by or on behalf of a Discloser,
+                  including before the Effective Date, to a Recipient in connection
+                  with this Agreement that (a) the Discloser identifies as "confidential",
+                  "proprietary", or the like; or (b) should be reasonably understood
+                  as confidential or proprietary due to its nature and the circumstances
+                  of its disclosure. Confidential Information includes the existence
+                  of this Agreement and the information on each Cover Page. Customer's
+                  Confidential Information includes non-public Customer Content and
+                  Provider's Confidential Information includes non-public information
+                  about the Product.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="font-semibold">"Cover Page"</span> means a document
+                  that is signed or electronically accepted by the parties that incorporates
+                  these Standard Terms, identifies Provider and Customer, and may
+                  include an Order Form, Key Terms, or both.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="font-semibold">"Covered Claim"</span> means either
+                  a Provider Covered Claim or Customer Covered Claim.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="font-semibold">"Customer Content"</span> means data,
+                  information, or materials submitted by or on behalf of Customer
+                  or Users to the Product, but excludes Feedback.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="font-semibold">"Discloser"</span> means a party to
+                  this Agreement when the party is providing or disclosing Confidential
+                  Information to the other party.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="font-semibold">"Documentation"</span> means the usage
+                  manuals and instructional materials for the Cloud Service or Software
+                  that are made available by Provider.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="font-semibold">"Feedback"</span> means suggestions,
+                  feedback, or comments about the Product or related offerings.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="font-semibold">"Force Majeure Event"</span> means
+                  an unforeseen event outside a party's reasonable control where
+                  the affected party took reasonable measures to avoid or mitigate
+                  the impacts of the event. Examples of these kinds of events include
+                  unpredicted natural disaster like a major earthquake, war, pandemic,
+                  riot, act of terrorism, or public utility or internet failure.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="font-semibold">"GDPR"</span> means European Union
+                  Regulation 2016/679 as implemented by local law in the relevant
+                  European Union member nation, and by section 3 of the United Kingdom's
+                  European Union (Withdrawal) Act of 2018 in the United Kingdom.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="font-semibold">"High Risk Activity"</span> means any
+                  situation where the use or failure of the Product could be reasonably
+                  expected to lead to death, bodily injury, or environmental damage.
+                  Examples include full or partial autonomous vehicle technology,
+                  medical life-support technology, emergency response services, nuclear
+                  facilities operation, and air traffic control.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="font-semibold">"Indemnifying Party"</span> means a
+                  party to this Agreement when the party is providing protection
+                  for a particular Covered Claim.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="font-semibold">"Key Terms"</span> means the portion
+                  of a Cover Page that includes the key legal details and definitions
+                  for this Agreement that are not defined in the Standard Terms.
+                  The Key Terms may include details about Covered Claims, set the
+                  Governing Law, or contain other details about this Agreement.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="font-semibold">"Order Form"</span> means the portion
+                  of a Cover Page that includes the key business details and definitions
+                  for this Agreement that are not defined in the Standard Terms.
+                  An Order Form may include details about the level of access and
+                  use granted to the Cloud Service, nature and timing of Professional
+                  Services, extent of Technical Support, or other details about the
+                  Product.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="font-semibold">"Personal Data"</span> will have the
+                  meaning(s) set forth in the Applicable Data Protection Laws for
+                  personal information, personal data, personally identifiable information,
+                  or other similar term.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="font-semibold">"Product"</span> means the Cloud Service,
+                  Software, and Documentation.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="font-semibold">"Prohibited Data"</span> means (a)
+                  patient, medical, or other protected health information regulated
+                  by the Health Insurance Portability and Accountability Act; (b)
+                  credit, debit, bank account, or other financial account numbers;
+                  (c) social security numbers, driver's license numbers, or other
+                  unique and private government ID numbers; (d) special categories
+                  of data as defined in the GDPR; and (e) other similar categories
+                  of sensitive information as set forth in the Applicable Data Protection
+                  Laws.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="font-semibold">"Protected Party"</span> means a party
+                  to this Agreement when the party is receiving the benefit of protection
+                  for a particular Covered Claim.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="font-semibold">"Recipient"</span> means a party to
+                  this Agreement when the party receives Confidential Information
+                  from the other party.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="font-semibold">"Software"</span> means the client-side
+                  software or applications made available by Provider for Customer
+                  to install, download (whether onto a machine or in a browser),
+                  or execute as part of the Product.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="font-semibold">"Usage Data"</span> means data and
+                  information about the provision, use, and performance of the Product
+                  and related offerings based on Customer's or User's use of the
+                  Product.
+                </li>
+                <li
+                  class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
+                >
+                  <span class="font-semibold">"User"</span> means any individual
+                  who uses the Product on Customer's behalf or through Customer's
+                  account.
+                </li>
+              </ol>
+            </li>
+          </ol>
         </div>
       </div>
     </div>

--- a/src/pages/teams/terms.astro
+++ b/src/pages/teams/terms.astro
@@ -40,7 +40,7 @@ import Layout from "../../layouts/Layout.astro";
         </div>
         <hr class="my-8" />
         <!-- Cover Page -->
-        <div class="space-y-3">
+        <div class="text-gray-700 space-y-3">
           <h2 class="font-bold text-2xl">Cover Page</h2>
           <div class="space-y-6">
             <!-- Order Form -->
@@ -130,7 +130,7 @@ import Layout from "../../layouts/Layout.astro";
         </div>
         <hr class="my-8" />
         <!-- Standard Terms -->
-        <div class="space-y-3">
+        <div class="text-gray-700 space-y-3">
           <h2 class="font-bold text-2xl">
             Standard Terms (Cloud Service Agreement)
           </h2>
@@ -337,7 +337,7 @@ import Layout from "../../layouts/Layout.astro";
             <li
               class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
             >
-              <span class="font-semibold text-lg">Payments & Taxes</span>
+              <span class="font-semibold text-lg">Payment & Taxes</span>
               <ol
                 class="space-y-4 list-inside pl-6 my-4 [counter-reset:section] marker:font-normal marker:text-base"
               >
@@ -502,7 +502,7 @@ import Layout from "../../layouts/Layout.astro";
               class="[counter-increment:section] marker:[content:counters(section,'.')_'._']"
             >
               <span class="font-semibold text-lg"
-                >Representation & Warranties</span
+                >Representations & Warranties</span
               >
               <ol
                 class="space-y-4 list-inside pl-6 my-4 [counter-reset:section] marker:font-normal marker:text-base"

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -18,52 +18,6 @@
   .placeholder-font-light::placeholder {
     @apply font-light;
   }
-
-  .standard-terms {
-    counter-reset: section;
-    @apply space-y-6 list-inside;
-
-    > li {
-      counter-increment: section;
-      @apply marker:[content:counters(section,'.')_'._'];
-
-      &::marker {
-        @apply font-semibold text-lg;
-      }
-
-      .clause-name {
-        @apply font-semibold text-lg;
-      }
-
-      p {
-        @apply pl-6 my-4;
-      }
-
-      ol {
-        @apply space-y-4 list-inside pl-6 my-4;
-        counter-reset: section;
-
-        li {
-          counter-increment: section;
-          @apply marker:[content:counters(section,'.')_'_'];
-
-          .sub-clause-name {
-            @apply underline;
-          }
-
-          ol {
-            @apply space-y-4 list-inside pl-6 my-4;
-            counter-reset: section;
-
-            li {
-              counter-increment: section;
-              @apply marker:[content:counter(section,lower-alpha)_'._'];
-            }
-          }
-        }
-      }
-    }
-  }
 }
 
 @layer components {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -18,6 +18,52 @@
   .placeholder-font-light::placeholder {
     @apply font-light;
   }
+
+  .standard-terms {
+    counter-reset: section;
+    @apply space-y-6 list-inside;
+
+    > li {
+      counter-increment: section;
+      @apply marker:[content:counters(section,'.')_'._'];
+
+      &::marker {
+        @apply font-semibold text-lg;
+      }
+
+      .clause-name {
+        @apply font-semibold text-lg;
+      }
+
+      p {
+        @apply pl-6 my-4;
+      }
+
+      ol {
+        @apply space-y-4 list-inside pl-6 my-4;
+        counter-reset: section;
+
+        li {
+          counter-increment: section;
+          @apply marker:[content:counters(section,'.')_'_'];
+
+          .sub-clause-name {
+            @apply underline;
+          }
+
+          ol {
+            @apply space-y-4 list-inside pl-6 my-4;
+            counter-reset: section;
+
+            li {
+              counter-increment: section;
+              @apply marker:[content:counter(section,lower-alpha)_'._'];
+            }
+          }
+        }
+      }
+    }
+  }
 }
 
 @layer components {


### PR DESCRIPTION
This PR adds the Terms of Service page for Livebook Teams.

Out of the scope of this PR:

- We're not linking to this page yet. In the near future, we'll link to it from the footer
- We're not asking for users of Livebook Teams to accept the Term of Service yet (with a checkbox during account creation for example). We'll do that in near future.