### PR TITLE
Remove settings page

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -13,14 +13,14 @@ import Icon from "../components/Icon.astro";
 
 export interface Props {
   title: string;
-  isDarkMode: boolean;
+  isDarkMode?: boolean;
   displaySponsors?: boolean;
   displayFooter?: string;
 }
 
 const {
   title,
-  isDarkMode,
+  isDarkMode = false,
   displaySponsors = true,
   displayFooter = "Livebook",
 } = Astro.props;
@@ -152,13 +152,6 @@ function isPathActive(path) {
               <Image src={badgeLogo} alt="" width="17" height="19" />
               <span class="mb-[-1.5px] font-semibold">Create badge</span>
             </a>
-            <a
-              class="p-2 flex items-center justify-center rounded-lg bg-gray-100 dark:bg-gray-700 dark:hover:bg-gray-800 text-gray-500 dark:text-gray-100 dark:border dark:border-gray-500 hover:bg-gray-100 focus:bg-gray-100 text-xl leading-none"
-              href="/settings"
-              aria-label="settings"
-            >
-              <Icon icon="settings-3-line" />
-            </a>
           </nav>
         </div>
       </div>
@@ -233,13 +226,6 @@ function isPathActive(path) {
           >
             <Image src={badgeLogo} alt="" width="17" height="19" />
             <span class="mb-[-1.5px] font-semibold">Create badge</span>
-          </a>
-          <a
-            class="p-2 rounded-lg bg-gray-100 border border-transparent text-gray-600 hover:bg-gray-50 focus:bg-gray-50 flex items-center justify-center space-x-1.5"
-            href="/settings"
-          >
-            <Icon icon="csettings-3-line" />
-            <span class="font-semibold text-sm">Settings</span>
           </a>
         </nav>
         <div class="flex-grow"></div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -113,7 +113,8 @@ const selectedIntegrations = integrations.filter((integration) =>
               Livebook Teams beta is here!
             </h2>
             <span class="max-w-sm sm:max-w-full text-gray-200 mt-6 px-2 sm:px-0"
-              >Build and deploy internal tools fast with Elixir and Livebook Teams.</span
+              >Build and deploy internal tools fast with Elixir and Livebook
+              Teams.</span
             >
             <a
               class="px-5 py-3 lg:px-6 lg:py-3 bg-white rounded-lg border border-gray-300 mt-8 plausible-event-name=home+teams+cta+click"

--- a/src/pages/settings.astro
+++ b/src/pages/settings.astro
@@ -1,8 +1,0 @@
----
-import SettingsSection from "../components/SettingsSection.astro";
-import Layout from "../layouts/Layout.astro";
----
-
-<Layout title="Settings">
-  <SettingsSection heading="Your Livebook installation" />
-</Layout>

--- a/src/pages/teams/pricing.astro
+++ b/src/pages/teams/pricing.astro
@@ -1,1 +1,2 @@
-At this moment, we only have the free pricing, for users who joined the free early access program.
+At this moment, we only have the free pricing, for users who joined the free
+early access program.


### PR DESCRIPTION
The settings are only relevant for running notebooks and we already have it on `/run`. We want to save the navbar space for other buttons.